### PR TITLE
Logging configuration

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,4 +1,4 @@
-package log
+package logging
 
 import (
 	"fmt"


### PR DESCRIPTION
Function `Configure` allows configuring level for logs output. It expects comma-separated level directives in one of three formats:
- `<log-level>` - e.g. `debug`
- `<subsystem>=<log-level>` - e.g. `keep-relay=info`
- `<subsystem-prefix>*=<log-level>` - e.g. `keep*=warn`