### PR TITLE
Add Circle CI test result reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   docker-go:
     docker:
-      - image: golang:1.13.0
+      - image: circleci/golang:1.13
 
 jobs:
   test-go:
@@ -11,13 +11,19 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create test directories
+          command: |
+            mkdir -p test-results/keep-common
+      - run:
           name: Run Go generators
           command: |
             go generate ./.../gen
       - run:
           name: Run Go tests
           command: |
-            go test ./.../
+            gotestsum --junitfile test-results/keep-common/unit-tests.xml
+      - store_test_results:
+          path: test-results
 workflows:
   version: 2
   test:


### PR DESCRIPTION
Circle CI now reports some summary info up top:

<img width="844" alt="Screen Shot 2019-09-27 at 10 03 49" src="https://user-images.githubusercontent.com/8245/65775403-1cc56100-e10e-11e9-83c1-ed2d53300580.png">

Common test failure and test runtime metadata is also collected over time for the insights section; e.g.: https://circleci.com/build-insights/gh/keep-network

More at https://circleci.com/docs/2.0/collect-test-data/ .

Lastly, I expect this will allow for much better output if and when we switch Circle to report builds using the GitHub Checks API, and Circle implements more complete Checks API integration.