### PR TITLE
Fix ambiguity in gas estimate log message

### DIFF
--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -161,7 +161,7 @@ func (lw *loggingWrapper) EstimateGas(ctx context.Context, msg ethereum.CallMsg)
 		return 0, err
 	}
 
-	lw.logger.Debugf("received gas price estimate: [%v]", gas)
+	lw.logger.Debugf("received gas estimate: [%v]", gas)
 	return gas, nil
 }
 


### PR DESCRIPTION
There are two estimates client needs to do before submitting a transaction:
- gas price estimate,
- gas estimate.

The amount of gas multiplied by gas price gives the cost of a transaction.

Here, we switch the logger message from  "received gas price estimate"
to "received gas estimate". This log prints the amount of gas, gas price is 
printed earlier in "received gas price suggestion" log message.