### PR TITLE
Payable function detection for overloaded functions

### DIFF
--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -95,7 +95,13 @@ func buildContractInfo(
 	payableMethods := make(map[string]struct{})
 	for _, methodPayableInfo := range payableInfo {
 		if methodPayableInfo.Payable {
-			payableMethods[methodPayableInfo.Name] = struct{}{}
+			name := methodPayableInfo.Name
+			_, ok := payableMethods[name]
+			for idx := 0; ok; idx++ {
+				name = fmt.Sprintf("%s%d", methodPayableInfo.Name, idx)
+				_, ok = payableMethods[name]
+			}
+			payableMethods[name] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
See https://github.com/keep-network/keep-core/pull/1165

Solidity allows for function overloading and Go does not. Versions of `go-ethereum prior` to `1.9.0` had a bug that only one from the overloaded function variants had Go binding generated.

go-ethereum fixed this problem in version `1.9.0` (ethereum/go-ethereum#17099) and for overloaded function, variants are named: `function`, `function0`, `function1`...

We need to adjust our code detecting if the function is payable to follow the function variants naming strategy from `go-ethereum` ABI generator.