### PR TITLE
Move ethereum block counter to keep-common

### DIFF
--- a/pkg/chain/ethereum/blockcounter/blockcounter.go
+++ b/pkg/chain/ethereum/blockcounter/blockcounter.go
@@ -1,4 +1,4 @@
-package ethereum
+package blockcounter
 
 import (
 	"context"

--- a/pkg/chain/ethereum/blockcounter/blockcounter_test.go
+++ b/pkg/chain/ethereum/blockcounter/blockcounter_test.go
@@ -1,4 +1,4 @@
-package ethereum
+package blockcounter
 
 import (
 	"context"


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-tecdsa/issues/252

Ethereum block counter should be moved grom `keep-core` to `keep-common` in order to allow reuse between projects.