### PR TITLE
Format `submitting transaction` method params to strings

### DIFF
--- a/tools/generators/ethereum/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethereum/contract_non_const_methods.go.tmpl
@@ -11,14 +11,15 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	{{$logger}}.Debug(
-		"submitting transaction {{$method.LowerName}}\n",
+		"submitting transaction {{$method.LowerName}}",
 		{{if $method.Params -}}
+		"params: ",
 		fmt.Sprint(
 			{{$method.Params}}
 		),
 		{{end -}}
 		{{if $method.Payable -}}
-		"\nValue: ", value,
+		"value: ", value,
 		{{- end}}
 	)
 

--- a/tools/generators/ethereum/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethereum/contract_non_const_methods_template_content.go
@@ -14,14 +14,15 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	{{$logger}}.Debug(
-		"submitting transaction {{$method.LowerName}}\n",
+		"submitting transaction {{$method.LowerName}}",
 		{{if $method.Params -}}
+		"params: ",
 		fmt.Sprint(
 			{{$method.Params}}
 		),
 		{{end -}}
 		{{if $method.Payable -}}
-		"\nValue: ", value,
+		"value: ", value,
 		{{- end}}
 	)
 


### PR DESCRIPTION
We updated the generator code for outputting transaction submission parameters. Previously the values were not converted to string correctly for `common.Address` type as it's a slice:
```
2020-03-19 21:38:03.503284 DEBUG keep-contract-BondedECDSAKeepFactory BondedECDSAKeepFactory.go:601: submitting transaction updateOperatorStatus
�Ŗg���ɱ#���|F>�G �:��D�>���\�V���`�9
```
Now we format parameters to strings.

There were also line breaks in the message, we removed the breaks to inline the message so it can be parsed correctly in the future.

Example of generated code:
```go
	becdsakfLogger.Debug(
		"submitting transaction updateOperatorStatus",
		fmt.Sprint(
			_operator,
			_application,
		),
	)
```

Sample log message:
```
23:39:12.256 DEBUG keep-contr: submitting transaction registerMemberCandidate with params:  [6 92 58 177 210 203 103 199 13 172 23 207 59 212 184 161 101 255 206 250] BondedECDSAKeepFactory.go:386
```

It's still not perfect as we should convert bytes to hexadecimal format but it should be enough for now as it's some improvement anyways.