### PR TITLE
Concurrent execution of the event handlers

### DIFF
--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -101,7 +101,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) subscribe{{$event.CapsName}}(
 					subscriptionMutex.Unlock()
 					return
 				}
-				success(
+				go success(
                     {{$event.ParamExtractors}}
 				)
 				subscriptionMutex.Unlock()

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -104,7 +104,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) subscribe{{$event.CapsName}}(
 					subscriptionMutex.Unlock()
 					return
 				}
-				success(
+				go success(
                     {{$event.ParamExtractors}}
 				)
 				subscriptionMutex.Unlock()
@@ -126,4 +126,5 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) subscribe{{$event.CapsName}}(
 	return subscription.NewEventSubscription(unsubscribeCallback), nil
 }
 
-{{- end -}}`
+{{- end -}}
+`


### PR DESCRIPTION
In this PR we allow concurrent execution of event handlers for a given subscription. Currently, when a new event comes it blocks the execution of handlers for any subsequent events.