### PR TITLE
Checking if a storage dir is readable and writable

### DIFF
--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -12,14 +12,21 @@ const (
 )
 
 // NewDiskHandle creates on-disk data persistence handle
-func NewDiskHandle(path string) Handle {
-	err := createDir(path, currentDir)
+func NewDiskHandle(path string) (Handle, error) {
+	err := checkStoragePermission(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = createDir(path, currentDir)
 	if err != nil {
 		logger.Errorf(
 			"failed while creating directory [%v]: [%v]",
 			currentDir,
 			err,
 		)
+
+		return nil, err
 	}
 
 	err = createDir(path, archiveDir)
@@ -29,11 +36,13 @@ func NewDiskHandle(path string) Handle {
 			archiveDir,
 			err,
 		)
+
+		return nil, err
 	}
 
 	return &diskPersistence{
 		dataDir: path,
-	}
+	}, nil
 }
 
 type diskPersistence struct {
@@ -63,6 +72,22 @@ func (ds *diskPersistence) Archive(directory string) error {
 
 func (ds *diskPersistence) getStorageCurrentDirPath() string {
 	return fmt.Sprintf("%s/%s", ds.dataDir, currentDir)
+}
+
+func checkStoragePermission(dirBasePath string) error {
+	_, err := ioutil.ReadDir(dirBasePath)
+	if err != nil {
+		return fmt.Errorf("cannot read from the storage directory: [%v]", err)
+	}
+
+	tempDir, err := ioutil.TempDir(dirBasePath, "temp")
+	if err != nil {
+		return fmt.Errorf("cannot write to the storage directory: [%v]", err)
+	}
+
+	defer os.RemoveAll(tempDir)
+
+	return nil
 }
 
 func createDir(dirBasePath, newDirName string) error {

--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -80,12 +80,12 @@ func checkStoragePermission(dirBasePath string) error {
 		return fmt.Errorf("cannot read from the storage directory: [%v]", err)
 	}
 
-	tempDir, err := ioutil.TempDir(dirBasePath, "temp")
+	tempFile, err := ioutil.TempFile(dirBasePath, "write-test.*.tmp")
 	if err != nil {
 		return fmt.Errorf("cannot write to the storage directory: [%v]", err)
 	}
 
-	defer os.RemoveAll(tempDir)
+	defer os.RemoveAll(tempFile.Name())
 
 	return nil
 }

--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -20,23 +20,11 @@ func NewDiskHandle(path string) (Handle, error) {
 
 	err = createDir(path, currentDir)
 	if err != nil {
-		logger.Errorf(
-			"failed while creating directory [%v]: [%v]",
-			currentDir,
-			err,
-		)
-
 		return nil, err
 	}
 
 	err = createDir(path, archiveDir)
 	if err != nil {
-		logger.Errorf(
-			"failed while creating directory [%v]: [%v]",
-			archiveDir,
-			err,
-		)
-
 		return nil, err
 	}
 

--- a/pkg/persistence/disk_persistence_test.go
+++ b/pkg/persistence/disk_persistence_test.go
@@ -61,14 +61,14 @@ func TestDiskPersistence_StoragePermission(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	_, err = NewDiskHandle(tempDir)
-	if !strings.Contains(err.Error(), errExpectedRead.Error()) {
+	if err == nil || !strings.Contains(err.Error(), errExpectedRead.Error()) {
 		t.Fatalf("error on read was supposed to be returned")
 	}
 
 	os.Chmod(tempDir, 0444) // dr--r--r
 
 	_, err = NewDiskHandle(tempDir)
-	if !strings.Contains(err.Error(), errExpectedWrite.Error()) {
+	if err == nil || !strings.Contains(err.Error(), errExpectedWrite.Error()) {
 		t.Fatalf("error on write was supposed to be returned")
 	}
 }

--- a/pkg/persistence/disk_persistence_test.go
+++ b/pkg/persistence/disk_persistence_test.go
@@ -3,10 +3,11 @@ package persistence
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"testing"
-	"io/ioutil"
 )
 
 var (
@@ -34,7 +35,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestDiskPersistence_Save(t *testing.T) {
-	diskPersistence := NewDiskHandle(dataDir)
+	diskPersistence, _ := NewDiskHandle(dataDir)
 	bytesToTest := []byte{115, 111, 109, 101, 10}
 
 	diskPersistence.Save(bytesToTest, dirName1, fileName11)
@@ -46,8 +47,40 @@ func TestDiskPersistence_Save(t *testing.T) {
 	}
 }
 
+func TestDiskPersistence_StoragePermission(t *testing.T) {
+	tempDir := "./data_storage"
+
+	err := os.Mkdir(tempDir, 000) // d---------
+	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		t.Fatalf("dir [%+v] was supposed to be created", tempDir)
+	}
+	defer os.RemoveAll(tempDir)
+
+	_, err = NewDiskHandle(tempDir)
+	if err == nil {
+		t.Fatalf("error was supposed to be returned")
+	}
+	
+	expectedReadErr := "cannot read from the storage directory"
+	if !strings.Contains(err.Error(), expectedReadErr) {
+		t.Fatalf("error on read was supposed to be returned")
+	}
+	
+	os.Chmod(tempDir, 0444) // dr--r--r
+	
+	_, err = NewDiskHandle(tempDir)
+	if err == nil {
+		t.Fatalf("error was supposed to be returned")
+	}
+	
+	expectedWriteErr := "cannot write to the storage directory"
+	if !strings.Contains(err.Error(), expectedWriteErr) {
+		t.Fatalf("error on write was supposed to be returned")
+	}
+}
+
 func TestDiskPersistence_ReadAll(t *testing.T) {
-	diskPersistence := NewDiskHandle(dataDir)
+	diskPersistence, _ := NewDiskHandle(dataDir)
 
 	bytesToTest := []byte{115, 111, 109, 101, 10}
 	expectedBytes := [][]byte{bytesToTest, bytesToTest, bytesToTest}
@@ -110,7 +143,7 @@ func TestDiskPersistence_ReadAll(t *testing.T) {
 }
 
 func TestDiskPersistence_Archive(t *testing.T) {
-	diskPersistence := NewDiskHandle(dataDir)
+	diskPersistence, _ := NewDiskHandle(dataDir)
 
 	pathMoveFrom := fmt.Sprintf("%s/%s", pathToCurrent, dirName1)
 	pathMoveTo := fmt.Sprintf("%s/%s", pathToArchive, dirName1)
@@ -147,7 +180,7 @@ func TestDiskPersistence_Archive(t *testing.T) {
 }
 
 func TestDiskPersistence_AppendToArchive(t *testing.T) {
-	diskPersistence := NewDiskHandle(dataDir)
+	diskPersistence, _ := NewDiskHandle(dataDir)
 
 	pathMoveFrom := fmt.Sprintf("%s/%s", pathToCurrent, dirName1)
 	pathMoveTo := fmt.Sprintf("%s/%s", pathToArchive, dirName1)
@@ -157,11 +190,11 @@ func TestDiskPersistence_AppendToArchive(t *testing.T) {
 	diskPersistence.Save(bytesToTest, dirName1, fileName11)
 	diskPersistence.Save(bytesToTest, dirName1, fileName12)
 	diskPersistence.Archive(dirName1)
-	
+
 	diskPersistence.Save(bytesToTest, dirName1, "/file13")
 	diskPersistence.Save(bytesToTest, dirName1, "/file14")
 	diskPersistence.Archive(dirName1)
-	
+
 	if _, err := os.Stat(pathMoveFrom); !os.IsNotExist(err) {
 		t.Fatalf("Dir [%+v] was supposed to be removed", pathMoveFrom)
 	}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-ecdsa/issues/336

In this PR we need to check if the storage dir specified in the config .toml file under `[Storage]:DataDir` has the right read&write permission.