### PR TITLE
Fix ethereum command function names

### DIFF
--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -275,10 +275,18 @@ func buildEventInfo(eventsByName map[string]abi.Event) []eventInfo {
 }
 
 func uppercaseFirst(str string) string {
+	if len(str) == 0 {
+		return str
+	}
+
 	return strings.ToUpper(str[0:1]) + str[1:]
 }
 
 func lowercaseFirst(str string) string {
+	if len(str) == 0 {
+		return str
+	}
+
 	return strings.ToLower(str[0:1]) + str[1:]
 }
 

--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -95,7 +95,7 @@ func buildContractInfo(
 	payableMethods := make(map[string]struct{})
 	for _, methodPayableInfo := range payableInfo {
 		if methodPayableInfo.Payable {
-			normalizedName := toCamelCase(methodPayableInfo.Name)
+			normalizedName := camelCase(methodPayableInfo.Name)
 			_, ok := payableMethods[normalizedName]
 			for idx := 0; ok; idx++ {
 				normalizedName = fmt.Sprintf("%s%d", normalizedName, idx)
@@ -138,7 +138,7 @@ func buildMethodInfo(
 	constMethods = make([]methodInfo, 0, len(methodsByName))
 
 	for name, method := range methodsByName {
-		normalizedName := toCamelCase(name)
+		normalizedName := camelCase(name)
 		dashedName := strings.ToLower(string(shortVarRegexp.ReplaceAll(
 			[]byte(normalizedName),
 			[]byte("-$0"),
@@ -278,7 +278,6 @@ func uppercaseFirst(str string) string {
 	if len(str) == 0 {
 		return str
 	}
-
 	return strings.ToUpper(str[0:1]) + str[1:]
 }
 
@@ -286,16 +285,15 @@ func lowercaseFirst(str string) string {
 	if len(str) == 0 {
 		return str
 	}
-
 	return strings.ToLower(str[0:1]) + str[1:]
 }
 
-func toCamelCase(input string) string {
+func camelCase(input string) string {
 	parts := strings.Split(input, "_")
 	for i, s := range parts {
 		if len(s) > 0 {
 			parts[i] = strings.ToUpper(s[:1]) + s[1:]
 		}
 	}
-	return strings.Join(parts, "")
+	return lowercaseFirst(strings.Join(parts, ""))
 }

--- a/tools/generators/ethereum/contract_parsing_test.go
+++ b/tools/generators/ethereum/contract_parsing_test.go
@@ -1,0 +1,69 @@
+package main
+
+import "testing"
+
+func TestLowercaseFirst(t *testing.T) {
+	var tests = map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"first lower case": {
+			input:    "helloWorld",
+			expected: "helloWorld",
+		},
+		"first upper case": {
+			input:    "HelloWorld",
+			expected: "helloWorld",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual := lowercaseFirst(test.input)
+			if actual != test.expected {
+				t.Errorf(
+					"unexpected output\nexpected: [%v]\nactual:   [%v]",
+					test.expected,
+					actual,
+				)
+			}
+		})
+	}
+}
+
+func TestUppercaseFirst(t *testing.T) {
+	var tests = map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"first upper case": {
+			input:    "HelloWorld",
+			expected: "HelloWorld",
+		},
+		"first lower case": {
+			input:    "helloWorld",
+			expected: "HelloWorld",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual := uppercaseFirst(test.input)
+			if actual != test.expected {
+				t.Errorf(
+					"unexpected output\nexpected: [%v]\nactual:   [%v]",
+					test.expected,
+					actual,
+				)
+			}
+		})
+	}
+}

--- a/tools/generators/ethereum/contract_parsing_test.go
+++ b/tools/generators/ethereum/contract_parsing_test.go
@@ -67,3 +67,44 @@ func TestUppercaseFirst(t *testing.T) {
 		})
 	}
 }
+
+func TestCamelCase(t *testing.T) {
+	var tests = map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"no underscores": {
+			input:    "HelloWorld",
+			expected: "helloWorld",
+		},
+		"with underscores": {
+			input:    "hello_world",
+			expected: "helloWorld",
+		},
+		"one underscore first": {
+			input:    "_beacon_callback",
+			expected: "beaconCallback",
+		},
+		"multiple underscores first": {
+			input:    "__beacon_callback",
+			expected: "beaconCallback",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual := camelCase(test.input)
+			if actual != test.expected {
+				t.Errorf(
+					"unexpected output\nexpected: [%v]\nactual:   [%v]",
+					test.expected,
+					actual,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/1579

- In https://github.com/keep-network/keep-common/commit/8ca95ff9de561f251db07c48cdcdfb76da079670#diff-10b1a8d2fcd46a80a34cd1e5bdf789c7L198 we introduced `toCamelCase` which normalizes function names using the same strategy as go-ethereum. This was needed so that we can have `__beaconCallback` function in `BondedECDSAKeepFactory`.
- `toCamelCase` uppercases the first letter, no matter if the function name starts with `_` or not. For example, `getGroupMembers` becomes `GetGroupMembers`.
- In `buildMethodInfo` we create `dashedName`:
    ```
    shortVarRegexp, err = regexp.Compile("([A-Z])[^A-Z]*")

    // (...)

	dashedName := strings.ToLower(string(shortVarRegexp.ReplaceAll(
		[]byte(normalizedName),
		[]byte("-$0"),
	)))
    ```

   Having the first letter uppercase, `GetGroupMembers` becomes `-get-group-members`.


The fix is easy, we need to ensure the first letter stays lowercase during the normalization. Later, in `buildMethodInfo` we specify explicitly where do we want lowercase and uppercase with `uppercaseFirst` and `lowercaseFirst`.

