### PR TITLE
Time cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,90 @@
+// Package cache provides a time cache implementation safe for concurrent use
+// without the need of additional locking.
+package cache
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-log"
+)
+
+var logger = log.Logger("keep-cache")
+
+// TimeCache provides a time cache safe for concurrent use by
+// multiple goroutines without additional locking or coordination.
+type TimeCache struct {
+	// all items in the cache in the order they were added
+	// most recent items are on the front of the indexer;
+	// it is used to optimize cache sweeping
+	indexer *list.List
+	// item in the cache with the timestamp it's been added
+	// to the cache the last time
+	cache map[string]time.Time
+	// the timespan after which entry in the cache is considered
+	// as outdated and can be removed from the cache
+	timespan time.Duration
+	mutex    sync.RWMutex
+}
+
+// NewTimeCache creates a new cache instance with provided timespan.
+func NewTimeCache(timespan time.Duration) *TimeCache {
+	return &TimeCache{
+		indexer:  list.New(),
+		cache:    make(map[string]time.Time),
+		timespan: timespan,
+	}
+}
+
+// Add adds an entry to the cache. Returns `true` if entry was not present in
+// the cache and was successfully added into it. Returns `false` if
+// entry is already in the cache. This method is synchronized.
+func (tc *TimeCache) Add(item string) bool {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
+
+	_, ok := tc.cache[item]
+	if ok {
+		return false
+	}
+
+	// sweep old entries (those for which caching timespan has passed)
+	for {
+		back := tc.indexer.Back()
+		if back == nil {
+			break
+		}
+
+		item := back.Value.(string)
+		itemTime, ok := tc.cache[item]
+		if !ok {
+			logger.Errorf(
+				"inconsistent cache state - expected item [%v] is not present",
+				item,
+			)
+			break
+		}
+
+		if time.Since(itemTime) > tc.timespan {
+			tc.indexer.Remove(back)
+			delete(tc.cache, item)
+		} else {
+			break
+		}
+	}
+
+	tc.cache[item] = time.Now()
+	tc.indexer.PushFront(item)
+	return true
+}
+
+// Has checks presence of an entry in the cache. Returns `true` if entry is
+// present and `false` otherwise.
+func (tc *TimeCache) Has(item string) bool {
+	tc.mutex.RLock()
+	defer tc.mutex.RUnlock()
+
+	_, ok := tc.cache[item]
+	return ok
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAdd(t *testing.T) {
+	cache := NewTimeCache(time.Minute)
+
+	cache.Add("test")
+
+	if !cache.Has("test") {
+		t.Fatal("should have 'test' key")
+	}
+}
+
+func TestConcurrentAdd(t *testing.T) {
+	cache := NewTimeCache(time.Minute)
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+
+	for i := 0; i < 10; i++ {
+		go func(item int) {
+			cache.Add(strconv.Itoa(item))
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 10; i++ {
+		if !cache.Has(strconv.Itoa(i)) {
+			t.Fatalf("should have '%v' key", i)
+		}
+	}
+}
+
+func TestExpiration(t *testing.T) {
+	cache := NewTimeCache(500 * time.Millisecond)
+	for i := 0; i < 6; i++ {
+		cache.Add(strconv.Itoa(i))
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if cache.Has(strconv.Itoa(0)) {
+		t.Fatal("should have dropped '0' key from the cache already")
+	}
+}


### PR DESCRIPTION
Time cache implementation safe for concurrent use without the need of additional locking and coordination. Extracted from `keep-ecdsa`, will be used there and for https://github.com/keep-network/keep-core/issues/1627.