### PR TITLE
Fixed from address for contract call options

### DIFF
--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -45,8 +45,9 @@ func New{{.Class}}(
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
-		From: contractAddress,
+		From: accountKey.Address,
 	}
+
 	transactorOptions := bind.NewKeyedTransactor(
 		accountKey.PrivateKey,
 	)

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -48,8 +48,9 @@ func New{{.Class}}(
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
-		From: contractAddress,
+		From: accountKey.Address,
 	}
+
 	transactorOptions := bind.NewKeyedTransactor(
 		accountKey.PrivateKey,
 	)


### PR DESCRIPTION
`from` address in call options for contract binding should be set to the address of the signer. `contractAddress` is supposed to be a destination of the call.