### PR TITLE
Max file length of 128 characters, moveAll error handling improvements

### DIFF
--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -9,6 +9,8 @@ import (
 const (
 	currentDir = "current"
 	archiveDir = "archive"
+
+	maxFileNameLength = 128
 )
 
 // NewDiskHandle creates on-disk data persistence handle
@@ -38,13 +40,29 @@ type diskPersistence struct {
 }
 
 func (ds *diskPersistence) Save(data []byte, dirName, fileName string) error {
+	if len(dirName) > maxFileNameLength {
+		return fmt.Errorf(
+			"the maximum directory name length of [%v] exceeded for [%v]",
+			maxFileNameLength,
+			dirName,
+		)
+	}
+
+	if len(fileName) > maxFileNameLength {
+		return fmt.Errorf(
+			"the maximum file name length of [%v] exceeded for [%v]",
+			maxFileNameLength,
+			fileName,
+		)
+	}
+
 	dirPath := ds.getStorageCurrentDirPath()
 	err := createDir(dirPath, dirName)
 	if err != nil {
 		return err
 	}
 
-	return write(fmt.Sprintf("%s/%s%s", dirPath, dirName, fileName), data)
+	return write(fmt.Sprintf("%s/%s/%s", dirPath, dirName, fileName), data)
 }
 
 func (ds *diskPersistence) ReadAll() (<-chan DataDescriptor, <-chan error) {
@@ -52,6 +70,14 @@ func (ds *diskPersistence) ReadAll() (<-chan DataDescriptor, <-chan error) {
 }
 
 func (ds *diskPersistence) Archive(directory string) error {
+	if len(directory) > maxFileNameLength {
+		return fmt.Errorf(
+			"the maximum directory name length of [%v] exceeded for [%v]",
+			maxFileNameLength,
+			directory,
+		)
+	}
+
 	from := fmt.Sprintf("%s/%s/%s", ds.dataDir, currentDir, directory)
 	to := fmt.Sprintf("%s/%s/%s", ds.dataDir, archiveDir, directory)
 


### PR DESCRIPTION
255 is a Unix length limit for most filesystems but some extensions like eCryptfs may impose lower limits. For eCryptfs it's 143 characters. We shouldn't be using file names longer than 128 characters anywhere so it makes sense to validate this limit in the persistence layer as a final check.

I have also improved the error handling in `moveAll` function. We are now explicit that we `os.Rename` only if the target directory does not exist (`os.IsNotExist(err)`) and we don't do that if it's any other type of an error. In such a case, we return from the function doing nothing.
We also no longer ignore errors from `ioutil.ReadDir`. If the error happens, we return from the function doing nothing.