### PR TITLE
Local nonce manager

### DIFF
--- a/pkg/chain/ethereum/ethutil/nonce.go
+++ b/pkg/chain/ethereum/ethutil/nonce.go
@@ -1,0 +1,89 @@
+package ethutil
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// NonceManager tracks the nonce for the account and allows to update it after
+// each successfully submitted transaction. Tracking the nonce locall is
+// required when transactions are submitted from multiple goroutines or when
+// multiple Ethereum clients are deployed behind a load balancer, there are no
+// sticky sessions and mempool synchronization between them takes some time.
+//
+// NonceManager provides no synchronization and is NOT safe for concurrent use.
+// It is up to the client code to implement the required synchronization.
+//
+// An example execution might work as follows:
+// 1. Obtain transaction lock,
+// 2. Calculate CurrentNonce(),
+// 3. Submit transaction with the calculated nonce,
+// 4. Call IncrementNonce(),
+// 5. Release transaction lock.
+type NonceManager struct {
+	account    common.Address
+	transactor bind.ContractTransactor
+	localNonce uint64
+}
+
+// NewNonceManager creates NonceManager instance for the provided account using
+// the provided contract transactor. Contract transactor is used for every
+// CurrentNonce execution to check the pending nonce value as seen by the
+// Ethereum client.
+func NewNonceManager(
+	account common.Address,
+	transactor bind.ContractTransactor,
+) *NonceManager {
+	return &NonceManager{
+		account:    account,
+		transactor: transactor,
+		localNonce: 0,
+	}
+}
+
+// CurrentNonce returns the nonce value that should be used for the next
+// transaction. The nonce is evaluated as the higher value from the local
+// nonce and pending nonce fetched from the Ethereum client.
+//
+// CurrentNonce is NOT safe for concurrent use. It is up to the code using this
+// function to provide the required synchronization, optionally including
+// IncrementNonce call as well.
+func (nm *NonceManager) CurrentNonce() (uint64, error) {
+	pendingNonce, err := nm.transactor.PendingNonceAt(
+		context.TODO(),
+		nm.account,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	if pendingNonce < nm.localNonce {
+		logger.Infof(
+			"local nonce [%v] is higher than pending [%v]; using the local one",
+			nm.localNonce,
+			pendingNonce,
+		)
+	}
+
+	if pendingNonce > nm.localNonce {
+		logger.Infof(
+			"local nonce [%v] is lower than pending [%v]; updating",
+			nm.localNonce,
+			pendingNonce,
+		)
+
+		nm.localNonce = pendingNonce
+	}
+
+	return nm.localNonce, nil
+}
+
+// IncrementNonce increments the value of the nonce kept locally by one.
+// This function is NOT safe for concurrent use. It is up to the client code
+// using this function to provide the required synchronization.
+func (nm *NonceManager) IncrementNonce() uint64 {
+	nm.localNonce++
+	return nm.localNonce
+}

--- a/pkg/chain/ethereum/ethutil/nonce.go
+++ b/pkg/chain/ethereum/ethutil/nonce.go
@@ -15,7 +15,7 @@ import (
 const localNonceTrustDuration = 5 * time.Second
 
 // NonceManager tracks the nonce for the account and allows to update it after
-// each successfully submitted transaction. Tracking the nonce locall is
+// each successfully submitted transaction. Tracking the nonce locally is
 // required when transactions are submitted from multiple goroutines or when
 // multiple Ethereum clients are deployed behind a load balancer, there are no
 // sticky sessions and mempool synchronization between them takes some time.

--- a/pkg/chain/ethereum/ethutil/nonce_test.go
+++ b/pkg/chain/ethereum/ethutil/nonce_test.go
@@ -1,0 +1,110 @@
+package ethutil
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestResolveAndIncrement(t *testing.T) {
+	tests := map[string]struct {
+		pendingNonce      uint64
+		localNonce        uint64
+		expectedNonce     uint64
+		expectedNextNonce uint64
+	}{
+		"pending and local the same": {
+			pendingNonce:      10,
+			localNonce:        10,
+			expectedNonce:     10,
+			expectedNextNonce: 11,
+		},
+		"pending nonce higher": {
+			pendingNonce:      121,
+			localNonce:        120,
+			expectedNonce:     121,
+			expectedNextNonce: 122,
+		},
+		"pending nonce lower": {
+			pendingNonce:      110,
+			localNonce:        111,
+			expectedNonce:     111,
+			expectedNextNonce: 112,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			transactor := &mockTransactor{test.pendingNonce}
+			manager := &NonceManager{
+				transactor: transactor,
+				localNonce: test.localNonce,
+			}
+
+			nonce, err := manager.CurrentNonce()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if nonce != test.expectedNonce {
+				t.Errorf(
+					"unexpected nonce\nexpected: [%v]\nactual:  [%v]",
+					test.expectedNonce,
+					nonce,
+				)
+			}
+
+			nextNonce := manager.IncrementNonce()
+
+			if nextNonce != test.expectedNextNonce {
+				t.Errorf(
+					"unexpected nonce\nexpected: [%v]\nactual:  [%v]",
+					test.expectedNextNonce,
+					nextNonce,
+				)
+			}
+		})
+	}
+}
+
+type mockTransactor struct {
+	nextNonce uint64
+}
+
+func (mt *mockTransactor) PendingCodeAt(
+	ctx context.Context,
+	account common.Address,
+) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (mt *mockTransactor) PendingNonceAt(
+	ctx context.Context,
+	account common.Address,
+) (uint64, error) {
+	return mt.nextNonce, nil
+}
+
+func (mt *mockTransactor) SuggestGasPrice(
+	ctx context.Context,
+) (*big.Int, error) {
+	panic("not implemented")
+}
+
+func (mt *mockTransactor) EstimateGas(
+	ctx context.Context,
+	call ethereum.CallMsg,
+) (gas uint64, err error) {
+	panic("not implemented")
+}
+
+func (mt *mockTransactor) SendTransaction(
+	ctx context.Context,
+	tx *types.Transaction,
+) error {
+	panic("not implemented")
+}

--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -221,6 +221,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         address,
         key,
         client,
+        ethutil.NewNonceManager(config.Account.Address, client),
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -221,7 +221,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         address,
         key,
         client,
-        ethutil.NewNonceManager(config.Account.Address, client),
+        ethutil.NewNonceManager(key.Address, client),
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -224,7 +224,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         address,
         key,
         client,
-        ethutil.NewNonceManager(config.Account.Address, client),
+        ethutil.NewNonceManager(key.Address, client),
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -224,6 +224,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         address,
         key,
         client,
+        ethutil.NewNonceManager(config.Account.Address, client),
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -34,6 +34,7 @@ type {{.Class}} struct {
 	callerOptions      *bind.CallOpts
 	transactorOptions  *bind.TransactOpts
 	errorResolver      *ethutil.ErrorResolver
+	nonceManager       *ethutil.NonceManager
 
 	transactionMutex *sync.Mutex
 }
@@ -42,6 +43,7 @@ func New{{.Class}}(
     contractAddress common.Address,
     accountKey *keystore.Key,
     backend bind.ContractBackend,
+    nonceManager *ethutil.NonceManager,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
@@ -78,6 +80,7 @@ func New{{.Class}}(
 		callerOptions:     callerOptions,
 		transactorOptions: transactorOptions,
 		errorResolver:     ethutil.NewErrorResolver(backend, &contractABI, &contractAddress),
+		nonceManager:      nonceManager,
 		transactionMutex:  transactionMutex,
 	}, nil
 }

--- a/tools/generators/ethereum/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethereum/contract_non_const_methods.go.tmpl
@@ -42,11 +42,17 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
+	nonce, err := {{$contract.ShortVar}}.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
 	transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		transactorOptions,
 		{{$method.Params}}
 	)
-
 	if err != nil {
 		return transaction, {{$contract.ShortVar}}.errorResolver.ResolveError(
 			err,
@@ -65,6 +71,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		"submitted transaction {{$method.LowerName}} with id: [%v]",
 		transaction.Hash().Hex(),
 	)
+
+	{{$contract.ShortVar}}.nonceManager.IncrementNonce()
 
 	return transaction, err
 }

--- a/tools/generators/ethereum/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethereum/contract_non_const_methods_template_content.go
@@ -45,11 +45,17 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
+	nonce, err := {{$contract.ShortVar}}.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
 	transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		transactorOptions,
 		{{$method.Params}}
 	)
-
 	if err != nil {
 		return transaction, {{$contract.ShortVar}}.errorResolver.ResolveError(
 			err,
@@ -68,6 +74,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		"submitted transaction {{$method.LowerName}} with id: [%v]",
 		transaction.Hash().Hex(),
 	)
+
+	{{$contract.ShortVar}}.nonceManager.IncrementNonce()
 
 	return transaction, err
 }

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -37,6 +37,7 @@ type {{.Class}} struct {
 	callerOptions      *bind.CallOpts
 	transactorOptions  *bind.TransactOpts
 	errorResolver      *ethutil.ErrorResolver
+	nonceManager       *ethutil.NonceManager
 
 	transactionMutex *sync.Mutex
 }
@@ -45,6 +46,7 @@ func New{{.Class}}(
     contractAddress common.Address,
     accountKey *keystore.Key,
     backend bind.ContractBackend,
+    nonceManager *ethutil.NonceManager,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
@@ -81,6 +83,7 @@ func New{{.Class}}(
 		callerOptions:     callerOptions,
 		transactorOptions: transactorOptions,
 		errorResolver:     ethutil.NewErrorResolver(backend, &contractABI, &contractAddress),
+		nonceManager:      nonceManager,
 		transactionMutex:  transactionMutex,
 	}, nil
 }


### PR DESCRIPTION
The nonce manager is used by the generated contracts to track the current nonce and update it after each successfully submitted transaction. Tracking the nonce locally is required when transactions are submitted from multiple goroutines or when Ethereum clients are deployed behind a load balancer and their mempools are not always in sync.

One important aspect that might not be clear at first is that we need to call `IncrementNonce()` only when the transaction has been successfully submitted to the mempool. Also, the nonce manager has to be a single instance stored between all contracts.

`NonceManager` itself does not provide any synchronization. All generated contracts use the transaction lock provided by the chain and that transaction lock makes nonces manipulation safe.

`NonceManager` considers the local nonce value as no longer valid and updates it to the pending nonce value as seen by the chain after 5 seconds of inactivity in computing nonces. This is to let us recover from potential mempool crashes before the last TX has been propagated to other mempools. However, as long as we submit transactions one after another, the local nonce value is what determines the nonce used in transaction.

I was considering keeping `NonceManager` in `contracts` package so that `CurrentNonce()` and `IncrementNonce()` (especially this one) are not accessible from anywhere else than `contracts` but it does not look right to me that the chain would have to create `contracts.NonceManager` and pass it to each contract as a constructor parameter. Given that we have the error resolver in `ethutil`, `NonceManager ` fits better in `ethutil` IMO.
