### PR TITLE
Continue when block number could not be parsed

### DIFF
--- a/pkg/chain/ethereum/blockcounter/blockcounter.go
+++ b/pkg/chain/ethereum/blockcounter/blockcounter.go
@@ -101,8 +101,8 @@ func (ebc *EthereumBlockCounter) receiveBlocks() {
 	for block := range ebc.subscriptionChannel {
 		topBlockNumber, err := strconv.ParseInt(block.Number, 0, 32)
 		if err != nil {
-			// FIXME Consider the right thing to do here.
 			logger.Errorf("error receiving a new block: [%v]", err)
+			continue
 		}
 
 		// receivedBlockHeight is the current blockchain height as just


### PR DESCRIPTION
In case block counter received a block with block number string that could not be parsed to an integer, we should log an error and skip the loop step (continue). Making any decisions based on the incorrect block number is not what we want to do.