### PR TITLE
Immediate first metric observation tick

### DIFF
--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -25,6 +25,8 @@ func (o *Observer) Observe(
 	tick time.Duration,
 ) {
 	go func() {
+		o.output.Set(o.input()) // execute the first check immediately
+
 		ticker := time.NewTicker(tick)
 		defer ticker.Stop()
 


### PR DESCRIPTION
Added an immediate metric observation tick when observation process is triggered.