### PR TITLE
Implementation of the Ethereum rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/urfave/cli v1.22.1
 	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20190925230517-ea99b82c7b93
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20190709231704-1e4459ed25ff // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -311,6 +312,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -45,6 +45,14 @@ type Config struct {
 	// allowed gas price is reached, no further resubmission attempts are
 	// performed.
 	MaxGasPrice uint64
+
+	// RequestsPerSecondLimit sets the maximum average number of requests
+	// per second which can be executed against the Ethereum node.
+	RequestsPerSecondLimit int
+
+	// ConcurrencyLimit sets the maximum number of concurrent requests which
+	// can be executed against the Ethereum node in the same time.
+	ConcurrencyLimit int
 }
 
 // ContractAddress finds a given contract's address configuration and returns it

--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -48,10 +48,14 @@ type Config struct {
 
 	// RequestsPerSecondLimit sets the maximum average number of requests
 	// per second which can be executed against the Ethereum node.
+	// All types of chain requests are rate-limited,
+	// including view function calls.
 	RequestsPerSecondLimit int
 
 	// ConcurrencyLimit sets the maximum number of concurrent requests which
-	// can be executed against the Ethereum node in the same time.
+	// can be executed against the Ethereum node at the same time.
+	// This limit affects all types of chain requests,
+	// including view function calls.
 	ConcurrencyLimit int
 }
 

--- a/pkg/chain/ethereum/ethutil/rate_limiter.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter.go
@@ -30,7 +30,7 @@ type RateLimiterConfig struct {
 	RequestsPerSecondLimit int
 
 	// ConcurrencyLimit sets the maximum number of concurrent requests which
-	// can be executed against the underlying contract backend in the same time.
+	// can be executed against the underlying contract backend at the same time.
 	ConcurrencyLimit int
 
 	// AcquirePermitTimeout determines how long a request can wait trying

--- a/pkg/chain/ethereum/ethutil/rate_limiter.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter.go
@@ -40,6 +40,8 @@ type RateLimiterConfig struct {
 
 // WrapRateLimiting wraps the given contract backend with rate limiting
 // capabilities with respect to the provided configuration.
+// All types of requests to the contract are rate-limited,
+// including view function calls.
 func WrapRateLimiting(
 	backend bind.ContractBackend,
 	config *RateLimiterConfig,

--- a/pkg/chain/ethereum/ethutil/rate_limiter.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter.go
@@ -1,0 +1,218 @@
+package ethutil
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/time/rate"
+	"math/big"
+	"time"
+)
+
+type rateLimiter struct {
+	bind.ContractBackend
+
+	limiter   *rate.Limiter
+	semaphore *semaphore.Weighted
+
+	acquirePermitTimeout time.Duration
+}
+
+// RateLimiterConfig represents the configuration of the rate limiter.
+type RateLimiterConfig struct {
+	// RequestsPerSecondLimit sets the maximum average number of requests
+	// per second. It's important to note that in short periods of time
+	// the actual average may exceed this limit slightly.
+	RequestsPerSecondLimit int
+
+	// ConcurrencyLimit sets the maximum number of concurrent requests which
+	// can be executed against the underlying contract backend in the same time.
+	ConcurrencyLimit int
+
+	// AcquirePermitTimeout determines how long a request can wait trying
+	// to acquire a permit from the rate limiter.
+	AcquirePermitTimeout time.Duration
+}
+
+// WrapRateLimiting wraps the given contract backend with rate limiting
+// capabilities with respect to the provided configuration.
+func WrapRateLimiting(
+	backend bind.ContractBackend,
+	config *RateLimiterConfig,
+) bind.ContractBackend {
+	rateLimiter := &rateLimiter{ContractBackend: backend}
+
+	if config.RequestsPerSecondLimit > 0 {
+		rateLimiter.limiter = rate.NewLimiter(
+			rate.Limit(config.RequestsPerSecondLimit),
+			1,
+		)
+	}
+
+	if config.ConcurrencyLimit > 0 {
+		rateLimiter.semaphore = semaphore.NewWeighted(
+			int64(config.ConcurrencyLimit),
+		)
+	}
+
+	if config.AcquirePermitTimeout > 0 {
+		rateLimiter.acquirePermitTimeout = config.AcquirePermitTimeout
+	} else {
+		rateLimiter.acquirePermitTimeout = 5 * time.Minute
+	}
+
+	return rateLimiter
+}
+
+func (rl *rateLimiter) acquirePermit() error {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		rl.acquirePermitTimeout,
+	)
+	defer cancel()
+
+	if rl.limiter != nil {
+		err := rl.limiter.Wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if rl.semaphore != nil {
+		err := rl.semaphore.Acquire(ctx, 1)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (rl *rateLimiter) releasePermit() {
+	if rl.semaphore != nil {
+		rl.semaphore.Release(1)
+	}
+}
+
+func (rl *rateLimiter) CodeAt(
+	ctx context.Context,
+	contract common.Address,
+	blockNumber *big.Int,
+) ([]byte, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.CodeAt(ctx, contract, blockNumber)
+}
+
+func (rl *rateLimiter) CallContract(
+	ctx context.Context,
+	call ethereum.CallMsg,
+	blockNumber *big.Int,
+) ([]byte, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.CallContract(ctx, call, blockNumber)
+}
+
+func (rl *rateLimiter) PendingCodeAt(
+	ctx context.Context,
+	account common.Address,
+) ([]byte, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.PendingCodeAt(ctx, account)
+}
+
+func (rl *rateLimiter) PendingNonceAt(
+	ctx context.Context,
+	account common.Address,
+) (uint64, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return 0, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.PendingNonceAt(ctx, account)
+}
+
+func (rl *rateLimiter) SuggestGasPrice(
+	ctx context.Context,
+) (*big.Int, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.SuggestGasPrice(ctx)
+}
+
+func (rl *rateLimiter) EstimateGas(
+	ctx context.Context,
+	call ethereum.CallMsg,
+) (uint64, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return 0, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.EstimateGas(ctx, call)
+}
+
+func (rl *rateLimiter) SendTransaction(
+	ctx context.Context,
+	tx *types.Transaction,
+) error {
+	err := rl.acquirePermit()
+	if err != nil {
+		return fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.SendTransaction(ctx, tx)
+}
+
+func (rl *rateLimiter) FilterLogs(
+	ctx context.Context,
+	query ethereum.FilterQuery,
+) ([]types.Log, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.FilterLogs(ctx, query)
+}
+
+func (rl *rateLimiter) SubscribeFilterLogs(
+	ctx context.Context,
+	query ethereum.FilterQuery,
+	ch chan<- types.Log,
+) (ethereum.Subscription, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.ContractBackend.SubscribeFilterLogs(ctx, query, ch)
+}

--- a/pkg/chain/ethereum/ethutil/rate_limiter_test.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter_test.go
@@ -153,8 +153,8 @@ func TestRateLimiter_RequestsPerSecondLimitOnly(t *testing.T) {
 			averageRequestsPerSecond := float64(requests) / duration.Seconds()
 
 			// The actual average can exceed the limit a little bit.
-			// Here we set the maximum acceptable deviation to 2%.
-			maxDeviation := 0.02
+			// Here we set the maximum acceptable deviation to 5%.
+			maxDeviation := 0.05
 
 			if averageRequestsPerSecond > (1+maxDeviation)*float64(requestsPerSecondLimit) {
 				t.Errorf(

--- a/pkg/chain/ethereum/ethutil/rate_limiter_test.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter_test.go
@@ -3,6 +3,7 @@ package ethutil
 import (
 	"context"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
@@ -34,95 +35,7 @@ func TestRateLimiter(t *testing.T) {
 		},
 	)
 
-	tests := map[string]struct {
-		function func() error
-	}{
-		"test CodeAt rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.CodeAt(
-					context.Background(),
-					[20]byte{},
-					nil,
-				)
-				return err
-			},
-		},
-		"test CallContract rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.CallContract(
-					context.Background(),
-					ethereum.CallMsg{},
-					nil,
-				)
-				return err
-			},
-		},
-		"test PendingCodeAt rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.PendingCodeAt(
-					context.Background(),
-					[20]byte{},
-				)
-				return err
-			},
-		},
-		"test PendingNonceAt rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.PendingNonceAt(
-					context.Background(),
-					[20]byte{},
-				)
-				return err
-			},
-		},
-		"test SuggestGasPrice rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.SuggestGasPrice(
-					context.Background(),
-				)
-				return err
-			},
-		},
-		"test EstimateGas rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.EstimateGas(
-					context.Background(),
-					ethereum.CallMsg{},
-				)
-				return err
-			},
-		},
-		"test SendTransaction rate limiting": {
-			function: func() error {
-				err := rateLimitingBackend.SendTransaction(
-					context.Background(),
-					nil,
-				)
-				return err
-			},
-		},
-		"test FilterLogs rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.FilterLogs(
-					context.Background(),
-					ethereum.FilterQuery{},
-				)
-				return err
-			},
-		},
-		"test SubscribeFilterLogs rate limiting": {
-			function: func() error {
-				_, err := rateLimitingBackend.SubscribeFilterLogs(
-					context.Background(),
-					ethereum.FilterQuery{},
-					nil,
-				)
-				return err
-			},
-		},
-	}
-
-	for testName, test := range tests {
+	for testName, test := range getTests(rateLimitingBackend) {
 		t.Run(testName, func(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(requests)
@@ -189,6 +102,148 @@ func TestRateLimiter(t *testing.T) {
 	}
 }
 
+func TestRateLimiter_RequestsPerSecondLimitOnly(t *testing.T) {
+	requestsPerSecondLimit := 500
+	concurrencyLimit := 0 // disable the concurrency limit
+	acquirePermitTimeout := time.Minute
+	requests := 500
+	requestDuration := 10 * time.Millisecond
+
+	backend := &mockBackend{
+		requestDuration,
+		make([]string, 0),
+		sync.Mutex{},
+	}
+
+	rateLimitingBackend := WrapRateLimiting(
+		backend,
+		&RateLimiterConfig{
+			RequestsPerSecondLimit: requestsPerSecondLimit,
+			ConcurrencyLimit:       concurrencyLimit,
+			AcquirePermitTimeout:   acquirePermitTimeout,
+		},
+	)
+
+	for testName, test := range getTests(rateLimitingBackend) {
+		t.Run(testName, func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			wg.Add(requests)
+
+			startSignal := make(chan struct{})
+
+			for i := 0; i < requests; i++ {
+				go func() {
+					<-startSignal
+
+					err := test.function()
+					if err != nil {
+						t.Errorf("unexpected error: [%v]", err)
+					}
+
+					wg.Done()
+				}()
+			}
+
+			startTime := time.Now()
+			close(startSignal)
+
+			wg.Wait()
+
+			duration := time.Now().Sub(startTime)
+			averageRequestsPerSecond := float64(requests) / duration.Seconds()
+
+			// The actual average can exceed the limit a little bit.
+			// Here we set the maximum acceptable deviation to 2%.
+			maxDeviation := 0.02
+
+			if averageRequestsPerSecond > (1+maxDeviation)*float64(requestsPerSecondLimit) {
+				t.Errorf(
+					"average requests per second exceeded the limit\n"+
+						"limit:  [%v]\n"+
+						"actual: [%v]",
+					requestsPerSecondLimit,
+					averageRequestsPerSecond,
+				)
+			}
+		})
+	}
+}
+
+func TestRateLimiter_ConcurrencyLimitOnly(t *testing.T) {
+	requestsPerSecondLimit := 0 // disable the requests per second limit
+	concurrencyLimit := 50
+	acquirePermitTimeout := time.Minute
+	requests := 500
+	requestDuration := 10 * time.Millisecond
+
+	backend := &mockBackend{
+		requestDuration,
+		make([]string, 0),
+		sync.Mutex{},
+	}
+
+	rateLimitingBackend := WrapRateLimiting(
+		backend,
+		&RateLimiterConfig{
+			RequestsPerSecondLimit: requestsPerSecondLimit,
+			ConcurrencyLimit:       concurrencyLimit,
+			AcquirePermitTimeout:   acquirePermitTimeout,
+		},
+	)
+
+	for testName, test := range getTests(rateLimitingBackend) {
+		t.Run(testName, func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			wg.Add(requests)
+
+			startSignal := make(chan struct{})
+
+			for i := 0; i < requests; i++ {
+				go func() {
+					<-startSignal
+
+					err := test.function()
+					if err != nil {
+						t.Errorf("unexpected error: [%v]", err)
+					}
+
+					wg.Done()
+				}()
+			}
+
+			close(startSignal)
+
+			wg.Wait()
+
+			maxConcurrency := 0
+			temporaryConcurrency := 0
+			for _, event := range backend.events {
+				if event == "start" {
+					temporaryConcurrency++
+				}
+
+				if event == "end" {
+					temporaryConcurrency--
+				}
+
+				if temporaryConcurrency > maxConcurrency {
+					maxConcurrency = temporaryConcurrency
+				}
+			}
+
+			if maxConcurrency > concurrencyLimit {
+				t.Errorf(
+					"max concurrency exceeded the limit\n"+
+						"limit:  [%v]\n"+
+						"actual: [%v]",
+					concurrencyLimit,
+					maxConcurrency,
+				)
+			}
+		})
+	}
+}
+
 func TestRateLimiter_AcquirePermitTimout(t *testing.T) {
 	requestsPerSecondLimit := 1
 	concurrencyLimit := 1
@@ -215,14 +270,7 @@ func TestRateLimiter_AcquirePermitTimout(t *testing.T) {
 	wg.Add(requests)
 
 	startSignal := make(chan struct{})
-	errorChannel := make(chan error, requests)
-	errors := make([]error, 0)
-
-	go func() {
-		for e := range errorChannel {
-			errors = append(errors, e)
-		}
-	}()
+	errors := make(chan error, requests)
 
 	for i := 0; i < requests; i++ {
 		go func() {
@@ -230,7 +278,7 @@ func TestRateLimiter_AcquirePermitTimout(t *testing.T) {
 
 			err := rateLimitingBackend.SendTransaction(context.Background(), nil)
 			if err != nil {
-				errorChannel <- err
+				errors <- err
 			}
 
 			wg.Done()
@@ -241,11 +289,12 @@ func TestRateLimiter_AcquirePermitTimout(t *testing.T) {
 
 	wg.Wait()
 
+	close(errors)
 	if len(errors) == 0 {
 		t.Fatalf("at least one timeout error should be present")
 	}
 
-	for _, e := range errors {
+	for e := range errors {
 		if !strings.Contains(e.Error(), "context deadline") {
 			t.Errorf(
 				"error should be related with the context deadline\n"+
@@ -347,4 +396,94 @@ func (mb *mockBackend) SubscribeFilterLogs(
 ) (ethereum.Subscription, error) {
 	mb.mockRequest()
 	return nil, nil
+}
+
+func getTests(
+	backend bind.ContractBackend,
+) map[string]struct{ function func() error } {
+	return map[string]struct{ function func() error }{
+		"test CodeAt": {
+			function: func() error {
+				_, err := backend.CodeAt(
+					context.Background(),
+					[20]byte{},
+					nil,
+				)
+				return err
+			},
+		},
+		"test CallContract": {
+			function: func() error {
+				_, err := backend.CallContract(
+					context.Background(),
+					ethereum.CallMsg{},
+					nil,
+				)
+				return err
+			},
+		},
+		"test PendingCodeAt": {
+			function: func() error {
+				_, err := backend.PendingCodeAt(
+					context.Background(),
+					[20]byte{},
+				)
+				return err
+			},
+		},
+		"test PendingNonceAt": {
+			function: func() error {
+				_, err := backend.PendingNonceAt(
+					context.Background(),
+					[20]byte{},
+				)
+				return err
+			},
+		},
+		"test SuggestGasPrice": {
+			function: func() error {
+				_, err := backend.SuggestGasPrice(
+					context.Background(),
+				)
+				return err
+			},
+		},
+		"test EstimateGas": {
+			function: func() error {
+				_, err := backend.EstimateGas(
+					context.Background(),
+					ethereum.CallMsg{},
+				)
+				return err
+			},
+		},
+		"test SendTransaction": {
+			function: func() error {
+				err := backend.SendTransaction(
+					context.Background(),
+					nil,
+				)
+				return err
+			},
+		},
+		"test FilterLogs": {
+			function: func() error {
+				_, err := backend.FilterLogs(
+					context.Background(),
+					ethereum.FilterQuery{},
+				)
+				return err
+			},
+		},
+		"test SubscribeFilterLogs": {
+			function: func() error {
+				_, err := backend.SubscribeFilterLogs(
+					context.Background(),
+					ethereum.FilterQuery{},
+					nil,
+				)
+				return err
+			},
+		},
+	}
 }

--- a/pkg/chain/ethereum/ethutil/rate_limiter_test.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter_test.go
@@ -1,0 +1,246 @@
+package ethutil
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const requestDuration = 250 * time.Millisecond
+
+func TestRateLimiter(t *testing.T) {
+	requestsPerSecondLimit := 200
+	concurrencyLimit := 50
+	acquirePermitTimeout := time.Minute
+	requests := 1000
+
+	backend := &mockBackend{make([]string, 0), sync.Mutex{}}
+
+	rateLimitingBackend := WrapRateLimiting(
+		backend,
+		&RateLimiterConfig{
+			RequestsPerSecondLimit: requestsPerSecondLimit,
+			ConcurrencyLimit:       concurrencyLimit,
+			AcquirePermitTimeout:   acquirePermitTimeout,
+		},
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(requests)
+
+	startSignal := make(chan struct{})
+
+	for i := 0; i < requests; i++ {
+		go func() {
+			<-startSignal
+
+			err := rateLimitingBackend.SendTransaction(context.Background(), nil)
+			if err != nil {
+				t.Errorf("unexpected error: [%v]", err)
+			}
+
+			wg.Done()
+		}()
+	}
+
+	startTime := time.Now()
+	close(startSignal)
+
+	wg.Wait()
+
+	duration := time.Now().Sub(startTime)
+	averageRequestsPerSecond := float64(requests) / duration.Seconds()
+
+	if averageRequestsPerSecond > float64(requestsPerSecondLimit) {
+		t.Errorf(
+			"average requests per second exceeded the limit\n"+
+				"limit:  [%v]\n"+
+				"actual: [%v]",
+			requestsPerSecondLimit,
+			averageRequestsPerSecond,
+		)
+	}
+
+	maxConcurrency := 0
+	temporaryConcurrency := 0
+	for _, event := range backend.events {
+		if event == "start" {
+			temporaryConcurrency++
+		}
+
+		if event == "end" {
+			temporaryConcurrency--
+		}
+
+		if temporaryConcurrency > maxConcurrency {
+			maxConcurrency = temporaryConcurrency
+		}
+	}
+
+	if maxConcurrency > concurrencyLimit {
+		t.Errorf(
+			"max concurrency exceeded the limit\n"+
+				"limit:  [%v]\n"+
+				"actual: [%v]",
+			concurrencyLimit,
+			maxConcurrency,
+		)
+	}
+
+	fmt.Printf(
+		"actual average requests per second: [%v]\n"+
+			"actual maximum concurrency: [%v]\n",
+		averageRequestsPerSecond,
+		maxConcurrency,
+	)
+}
+
+func TestRateLimiter_AcquirePermitTimout(t *testing.T) {
+	requestsPerSecondLimit := 1
+	concurrencyLimit := 1
+	acquirePermitTimeout := 10 * time.Millisecond
+	requests := 3
+
+	backend := &mockBackend{make([]string, 0), sync.Mutex{}}
+
+	rateLimitingBackend := WrapRateLimiting(
+		backend,
+		&RateLimiterConfig{
+			RequestsPerSecondLimit: requestsPerSecondLimit,
+			ConcurrencyLimit:       concurrencyLimit,
+			AcquirePermitTimeout:   acquirePermitTimeout,
+		},
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(requests)
+
+	startSignal := make(chan struct{})
+	errorChannel := make(chan error, requests)
+	errors := make([]error, 0)
+
+	go func() {
+		for e := range errorChannel {
+			errors = append(errors, e)
+		}
+	}()
+
+	for i := 0; i < requests; i++ {
+		go func() {
+			<-startSignal
+
+			err := rateLimitingBackend.SendTransaction(context.Background(), nil)
+			if err != nil {
+				errorChannel <- err
+			}
+
+			wg.Done()
+		}()
+	}
+
+	close(startSignal)
+
+	wg.Wait()
+
+	if len(errors) == 0 {
+		t.Fatalf("at least one timeout error should be present")
+	}
+
+	for _, e := range errors {
+		if !strings.Contains(e.Error(), "context deadline") {
+			t.Errorf(
+				"error should be related with the context deadline\n"+
+					"actual error: [%v]",
+				e,
+			)
+		}
+	}
+}
+
+type mockBackend struct {
+	events []string
+	mutex  sync.Mutex
+}
+
+func (mb *mockBackend) CodeAt(
+	ctx context.Context,
+	contract common.Address,
+	blockNumber *big.Int,
+) ([]byte, error) {
+
+	return nil, nil
+}
+
+func (mb *mockBackend) CallContract(
+	ctx context.Context,
+	call ethereum.CallMsg,
+	blockNumber *big.Int,
+) ([]byte, error) {
+	return nil, nil
+}
+
+func (mb *mockBackend) PendingCodeAt(
+	ctx context.Context,
+	account common.Address,
+) ([]byte, error) {
+	return nil, nil
+}
+
+func (mb *mockBackend) PendingNonceAt(
+	ctx context.Context,
+	account common.Address,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (mb *mockBackend) SuggestGasPrice(
+	ctx context.Context,
+) (*big.Int, error) {
+	return nil, nil
+}
+
+func (mb *mockBackend) EstimateGas(
+	ctx context.Context,
+	call ethereum.CallMsg,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (mb *mockBackend) SendTransaction(
+	ctx context.Context,
+	tx *types.Transaction,
+) error {
+	mb.mutex.Lock()
+	mb.events = append(mb.events, "start")
+	mb.mutex.Unlock()
+
+	time.Sleep(requestDuration)
+
+	mb.mutex.Lock()
+	mb.events = append(mb.events, "end")
+	mb.mutex.Unlock()
+
+	return nil
+}
+
+func (mb *mockBackend) FilterLogs(
+	ctx context.Context,
+	query ethereum.FilterQuery,
+) ([]types.Log, error) {
+	return nil, nil
+}
+
+func (mb *mockBackend) SubscribeFilterLogs(
+	ctx context.Context,
+	query ethereum.FilterQuery,
+	ch chan<- types.Log,
+) (ethereum.Subscription, error) {
+	return nil, nil
+}

--- a/pkg/chain/ethereum/ethutil/rate_limiter_test.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter_test.go
@@ -174,7 +174,6 @@ func (mb *mockBackend) CodeAt(
 	contract common.Address,
 	blockNumber *big.Int,
 ) ([]byte, error) {
-
 	return nil, nil
 }
 


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/524

Here we implement a rate-limiting wrapper for the Ethereum contract backend. Regarding the internals, it can limit the average number of requests per second using the token bucket algorithm and the request concurrency using a semaphore. 