### PR TITLE
Add GoSec workflow

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,20 @@
+name: Gosec
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - uses: actions/checkout@v2
+      - uses: securego/gosec@master
+        with:
+          args: ./...

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -35,7 +35,9 @@ func AddressFromHex(hex string) (common.Address, error) {
 
 // DecryptKeyFile reads in a key file and uses the password to decrypt it.
 func DecryptKeyFile(keyFile, password string) (*keystore.Key, error) {
-	data, err := ioutil.ReadFile(keyFile) // #nosec
+	// #nosec G304 (file path provided as taint input)
+	// This line is used to read a local key file. There is no user input.
+	data, err := ioutil.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read KeyFile %s [%v]", keyFile, err)
 	}

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -35,7 +35,7 @@ func AddressFromHex(hex string) (common.Address, error) {
 
 // DecryptKeyFile reads in a key file and uses the password to decrypt it.
 func DecryptKeyFile(keyFile, password string) (*keystore.Key, error) {
-	data, err := ioutil.ReadFile(keyFile)
+	data, err := ioutil.ReadFile(keyFile) // #nosec
 	if err != nil {
 		return nil, fmt.Errorf("unable to read KeyFile %s [%v]", keyFile, err)
 	}
@@ -141,7 +141,7 @@ func CallAtBlock(
 // the true gas limit requirement as other transactions may be added or removed by miners,
 // but it should provide a basis for setting a reasonable default.
 func EstimateGas(
-	from common.Address, 
+	from common.Address,
 	to common.Address,
 	method string,
 	contractABI *abi.ABI,

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -38,7 +38,7 @@ func OrganizeImports(codeBuffer *bytes.Buffer, filePath string) error {
 // error writing the file.
 func SaveBufferToFile(buffer *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
-	defer file.Close()
+	defer file.Close() // #nosec
 	if err != nil {
 		return fmt.Errorf("output file %s creation failed [%v]", filePath, err)
 	}

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -38,7 +38,13 @@ func OrganizeImports(codeBuffer *bytes.Buffer, filePath string) error {
 // error writing the file.
 func SaveBufferToFile(buffer *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
-	defer file.Close() // #nosec
+
+	// #nosec G104 (audit errors not checked)
+	// This line is placed in the auxiliary generator code,
+	// not in the core application. Also, the Close function returns only
+	// the error. It doesn't return any other values which can be a security
+	// threat when used without checking the error.
+	defer file.Close()
 	if err != nil {
 		return fmt.Errorf("output file %s creation failed [%v]", filePath, err)
 	}

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -39,7 +39,7 @@ func OrganizeImports(codeBuffer *bytes.Buffer, filePath string) error {
 func SaveBufferToFile(buffer *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
 
-	// #nosec G104 (audit errors not checked)
+	// #nosec G104 G307 (audit errors not checked & deferring unsafe method)
 	// This line is placed in the auxiliary generator code,
 	// not in the core application. Also, the Close function returns only
 	// the error. It doesn't return any other values which can be a security

--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -140,7 +140,10 @@ func write(filePath string, data []byte) error {
 
 // read a file from a file system
 func read(filePath string) ([]byte, error) {
-	readFile, err := os.Open(filePath) // #nosec
+	// #nosec G304 (file path provided as taint input)
+	// This line opens a file from the predefined storage.
+	// There is no user input.
+	readFile, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/persistence/disk_persistence.go
+++ b/pkg/persistence/disk_persistence.go
@@ -123,26 +123,29 @@ func write(filePath string, data []byte) error {
 		return err
 	}
 
-	defer writeFile.Close()
+	defer closeFile(writeFile)
 
 	_, err = writeFile.Write(data)
 	if err != nil {
 		return err
 	}
 
-	writeFile.Sync()
+	err = writeFile.Sync()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
 // read a file from a file system
 func read(filePath string) ([]byte, error) {
-	readFile, err := os.Open(filePath)
+	readFile, err := os.Open(filePath) // #nosec
 	if err != nil {
 		return nil, err
 	}
 
-	defer readFile.Close()
+	defer closeFile(readFile)
 
 	data, err := ioutil.ReadAll(readFile)
 	if err != nil {
@@ -150,6 +153,13 @@ func read(filePath string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+func closeFile(file *os.File) {
+	err := file.Close()
+	if err != nil {
+		logger.Errorf("could not close file [%v]: [%v]", file.Name(), err)
+	}
 }
 
 // readAll reads all files from the provided directoryPath and outputs them

--- a/tools/generators/ethereum/contract.go
+++ b/tools/generators/ethereum/contract.go
@@ -61,7 +61,11 @@ func main() {
 	contractOutputPath := flag.Arg(1)
 	commandOutputPath := flag.Arg(2)
 
-	abiFile, err := ioutil.ReadFile(abiPath) // #nosec
+	// #nosec G304 (file path provided as taint input)
+	// This line is placed in the auxiliary generator code,
+	// not in the core application. User input has to be passed to
+	// provide a path to the contract ABI.
+	abiFile, err := ioutil.ReadFile(abiPath)
 	if err != nil {
 		panic(fmt.Sprintf(
 			"Failed to read ABI file at [%v]: [%v].",
@@ -223,7 +227,13 @@ func organizeImports(outFile string, buf *bytes.Buffer) error {
 // Stores the Buffer `buf` content to a file in `filePath`
 func saveBufferToFile(buf *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
-	defer file.Close() // #nosec
+
+	// #nosec G104 (audit errors not checked)
+	// This line is placed in the auxiliary generator code,
+	// not in the core application. Also, the Close function returns only
+	// the error. It doesn't return any other values which can be a security
+	// threat when used without checking the error.
+	defer file.Close()
 	if err != nil {
 		return fmt.Errorf("output file %s creation failed [%v]", filePath, err)
 	}

--- a/tools/generators/ethereum/contract.go
+++ b/tools/generators/ethereum/contract.go
@@ -228,7 +228,7 @@ func organizeImports(outFile string, buf *bytes.Buffer) error {
 func saveBufferToFile(buf *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
 
-	// #nosec G104 (audit errors not checked)
+	// #nosec G104 G307 (audit errors not checked & deferring unsafe method)
 	// This line is placed in the auxiliary generator code,
 	// not in the core application. Also, the Close function returns only
 	// the error. It doesn't return any other values which can be a security

--- a/tools/generators/ethereum/contract.go
+++ b/tools/generators/ethereum/contract.go
@@ -61,7 +61,7 @@ func main() {
 	contractOutputPath := flag.Arg(1)
 	commandOutputPath := flag.Arg(2)
 
-	abiFile, err := ioutil.ReadFile(abiPath)
+	abiFile, err := ioutil.ReadFile(abiPath) // #nosec
 	if err != nil {
 		panic(fmt.Sprintf(
 			"Failed to read ABI file at [%v]: [%v].",
@@ -223,7 +223,7 @@ func organizeImports(outFile string, buf *bytes.Buffer) error {
 // Stores the Buffer `buf` content to a file in `filePath`
 func saveBufferToFile(buf *bytes.Buffer, filePath string) error {
 	file, err := os.Create(filePath)
-	defer file.Close()
+	defer file.Close() // #nosec
 	if err != nil {
 		return fmt.Errorf("output file %s creation failed [%v]", filePath, err)
 	}

--- a/tools/generators/promise/promise.go
+++ b/tools/generators/promise/promise.go
@@ -96,12 +96,12 @@ func generatePromisesCode(generationDir string, promisesConfig []promiseConfig) 
 		return fmt.Errorf("template creation failed [%v]", err)
 	}
 
-	for _, promiseConfig := range promisesConfig {
-		outputFile := promiseConfig.Filename
+	for i := range promisesConfig {
+		outputFile := promisesConfig[i].Filename
 		outputFilePath := path.Join(generationDir, outputFile)
 
 		// Generate promise code.
-		buffer, err := generateCode(promiseTemplate, &promiseConfig, outputFilePath)
+		buffer, err := generateCode(promiseTemplate, &promisesConfig[i], outputFilePath)
 		if err != nil {
 			return fmt.Errorf("promise generation failed [%v]", err)
 		}

--- a/tools/generators/template/template.go
+++ b/tools/generators/template/template.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	templateFile := os.Args[templateFileArgIndex]
-	templateContents, err := ioutil.ReadFile(templateFile)
+	templateContents, err := ioutil.ReadFile(templateFile) // #nosec
 	if err != nil {
 		errorAndExit(fmt.Sprintf("Failed to open template file: [%v].", err))
 	}

--- a/tools/generators/template/template.go
+++ b/tools/generators/template/template.go
@@ -30,7 +30,12 @@ func main() {
 	}
 
 	templateFile := os.Args[templateFileArgIndex]
-	templateContents, err := ioutil.ReadFile(templateFile) // #nosec
+
+	// #nosec G304 (file path provided as taint input)
+	// This line is placed in the auxiliary generator code,
+	// not in the core application. User input has to be passed to provide a
+	// path to the template file.
+	templateContents, err := ioutil.ReadFile(templateFile)
 	if err != nil {
 		errorAndExit(fmt.Sprintf("Failed to open template file: [%v].", err))
 	}


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/2007

Here we introduce the [GoSec](https://github.com/securego/gosec) scan workflow to the Github Actions pipeline and deal with all discovered problems.

Summary of `#nosec` exceptions and their motivation:

1. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/pkg/chain/ethereum/ethutil/ethutil.go#L40
Rule G304: File path provided as taint input
Motivation: We use this line to read a local key file. There is no user input.

2. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/pkg/generate/generate.go#L47
Rule G104: Audit errors not checked
Rule G307: Deferring a method which returns an error
Motivation: This line is placed in the auxiliary generator code, not in the core application. Also, the `Close` function returns only the error. It doesn't return any other values which can be a security threat when used without checking the error.

3. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/pkg/persistence/disk_persistence.go#L146
Rule G304: File path provided as taint input
Motivation: There is no user input.

4. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/tools/generators/ethereum/contract.go#L68
Rule G304: File path provided as taint input
Motivation: This line is placed in the auxiliary generator code, not in the core application. User input has to be passed to provide a path to the contract ABI.

5. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/tools/generators/ethereum/contract.go#L236
Rule G104: Audit errors not checked
Rule G307: Deferring a method which returns an error
Motivation: This line is placed in the auxiliary generator code, not in the core application. Also, the `Close` function returns only the error. It doesn't return any other values which can be a security threat when used without checking the error.

6. https://github.com/keep-network/keep-common/blob/024f151c484a5c59a0667dd10907236303746450/tools/generators/template/template.go#L38
Rule G304: File path provided as taint input
Motivation: This line is placed in the auxiliary generator code, not in the core application. User input has to be passed to provide a path to the template file.




