### PR TITLE
Add snapshot feature to the disk persistence layer

### DIFF
--- a/pkg/persistence/encrypted_persistence.go
+++ b/pkg/persistence/encrypted_persistence.go
@@ -34,6 +34,15 @@ func (ep *encryptedPersistence) Save(data []byte, directory string, name string)
 	return ep.delegate.Save(encrypted, directory, name)
 }
 
+func (ep *encryptedPersistence) Snapshot(data []byte, directory string, name string) error {
+	encrypted, err := ep.box.Encrypt(data)
+	if err != nil {
+		return err
+	}
+
+	return ep.delegate.Snapshot(encrypted, directory, name)
+}
+
 func (ep *encryptedPersistence) ReadAll() (<-chan DataDescriptor, <-chan error) {
 	outputData := make(chan DataDescriptor)
 	outputErrors := make(chan error)

--- a/pkg/persistence/encrypted_persistence_test.go
+++ b/pkg/persistence/encrypted_persistence_test.go
@@ -85,9 +85,18 @@ func TestSaveReadAndDecryptData(t *testing.T) {
 	}
 }
 
+func TestEncryptedSnapshot(t *testing.T) {
+
+}
+
 type delegatePersistenceMock struct{}
 
 func (dpm *delegatePersistenceMock) Save(data []byte, directory string, name string) error {
+	// noop
+	return nil
+}
+
+func (dpm *delegatePersistenceMock) Snapshot(data []byte, directory string, name string) error {
 	// noop
 	return nil
 }

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -1,5 +1,5 @@
 // Package persistence adds a layer which handles data storage. This package
-// separates the data from the business layer and is responsible for saving and 
+// separates the data from the business layer and is responsible for saving and
 // retrieving it.
 package persistence
 
@@ -15,6 +15,11 @@ type Handle interface {
 	// provided directory appropriate for the given persistent storage
 	// implementation.
 	Save(data []byte, directory string, name string) error
+
+	// Snapshot takes the provided data and persists it as an unique snapshot
+	// file in the provided directory appropriate for the given persistent
+	// storage implementation.
+	Snapshot(data []byte, directory string, name string) error
 
 	// ReadAll returns all non-archived data. It returns two channels: the first
 	// channel returned is a non-buffered channel streaming DataDescriptors of


### PR DESCRIPTION
Implemented a new `Snapshot` method in the disk persistence layer. It allows storing a unique timestamped snapshot
file of given data in a dedicated `snapshot` directory. 