### PR TITLE
Add `BalanceAlertThreshold` property

### DIFF
--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	// This limit affects all types of chain requests,
 	// including view function calls.
 	ConcurrencyLimit int
+
+	// BalanceAlertThreshold defines a minimum value of the operator's account
+	// balance below which an alert will be triggered.
+	BalanceAlertThreshold uint64
 }
 
 // ContractAddress finds a given contract's address configuration and returns it


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/551
Refs: https://github.com/keep-network/keep-core/issues/2163

Added a new property in the Ethereum config which allow defining a minimum value of the operator's account balance below which an alert will be triggered.