### PR TITLE
Trim underscore prefix while generating event params

### DIFF
--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -278,6 +278,9 @@ func uppercaseFirst(str string) string {
 	if len(str) == 0 {
 		return str
 	}
+
+	str = strings.TrimPrefix(str, "_")
+
 	return strings.ToUpper(str[0:1]) + str[1:]
 }
 
@@ -285,6 +288,9 @@ func lowercaseFirst(str string) string {
 	if len(str) == 0 {
 		return str
 	}
+
+	str = strings.TrimPrefix(str, "_")
+
 	return strings.ToLower(str[0:1]) + str[1:]
 }
 


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/574

Underscore prefixes should be trimmed while capitalizing and uncapitalizing the first letter of the event params. This change
is required because `abigen` does the same while generating the underlying contract binding so names must be aligned to
avoid compilation errors.