### PR TITLE
Increase the local nonce trust duration

### DIFF
--- a/pkg/chain/ethereum/ethutil/nonce.go
+++ b/pkg/chain/ethereum/ethutil/nonce.go
@@ -12,7 +12,7 @@ import (
 // from the chain. The local value is invalidated after the certain duration to
 // let the nonce recover in case the mempool crashed before propagating the last
 // transaction sent.
-const localNonceTrustDuration = 5 * time.Second
+const localNonceTrustDuration = 30 * time.Second
 
 // NonceManager tracks the nonce for the account and allows to update it after
 // each successfully submitted transaction. Tracking the nonce locally is


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-ecdsa/issues/604

Increased the `localNonceTrustDuration` value from 5 to 30 seconds. This change should help avoid nonce duplications in case the mempool synchronization process between the load-balanced Ethereum nodes takes more time than 5 seconds.