### PR TITLE
Add chain confirmation waiter

### DIFF
--- a/pkg/chain/ethereum/ethutil/confirmations.go
+++ b/pkg/chain/ethereum/ethutil/confirmations.go
@@ -1,0 +1,35 @@
+package ethutil
+
+import "fmt"
+
+// BlockHeightWaiter provides the ability to wait for a given block height.
+type BlockHeightWaiter interface {
+	WaitForBlockHeight(blockNumber uint64) error
+}
+
+// WaitForChainConfirmation ensures that after receiving specific number of block
+// confirmations the state of the chain is actually as expected. It waits for
+// predefined number of blocks since the start block number provided. After the
+// required block number is reached it performs a check of the chain state with
+// a provided function returning a boolean value.
+func WaitForChainConfirmation(
+	blockHeightWaiter BlockHeightWaiter,
+	startBlockNumber uint64,
+	blockConfirmations uint64,
+	stateCheck func() (bool, error),
+) (bool, error) {
+	blockHeight := startBlockNumber + blockConfirmations
+	logger.Infof("waiting for block [%d] to confirm chain state", blockHeight)
+
+	err := blockHeightWaiter.WaitForBlockHeight(blockHeight)
+	if err != nil {
+		return false, fmt.Errorf("failed to wait for block height: [%v]", err)
+	}
+
+	result, err := stateCheck()
+	if err != nil {
+		return false, fmt.Errorf("failed to get chain state confirmation: [%v]", err)
+	}
+
+	return result, nil
+}

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -213,35 +213,3 @@ func (lw *loggingWrapper) EstimateGas(ctx context.Context, msg ethereum.CallMsg)
 func WrapCallLogging(logger log.EventLogger, client EthereumClient) EthereumClient {
 	return &loggingWrapper{client, logger}
 }
-
-// BlockHeightWaiter provides the ability to wait for a given block height.
-type BlockHeightWaiter interface {
-	WaitForBlockHeight(blockNumber uint64) error
-}
-
-// WaitForChainConfirmation ensures that after receiving specific number of block
-// confirmations the state of the chain is actually as expected. It waits for
-// predefined number of blocks since the start block number provided. After the
-// required block number is reached it performs a check of the chain state with
-// a provided function returning a boolean value.
-func WaitForChainConfirmation(
-	blockHeightWaiter BlockHeightWaiter,
-	startBlockNumber uint64,
-	blockConfirmations uint64,
-	stateCheck func() (bool, error),
-) (bool, error) {
-	blockHeight := startBlockNumber + blockConfirmations
-	logger.Infof("waiting for block [%d] to confirm chain state", blockHeight)
-
-	err := blockHeightWaiter.WaitForBlockHeight(blockHeight)
-	if err != nil {
-		return false, fmt.Errorf("failed to wait for block height: [%v]", err)
-	}
-
-	result, err := stateCheck()
-	if err != nil {
-		return false, fmt.Errorf("failed to get chain state confirmation: [%v]", err)
-	}
-
-	return result, nil
-}

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -213,3 +213,35 @@ func (lw *loggingWrapper) EstimateGas(ctx context.Context, msg ethereum.CallMsg)
 func WrapCallLogging(logger log.EventLogger, client EthereumClient) EthereumClient {
 	return &loggingWrapper{client, logger}
 }
+
+// BlockHeightWaiter provides the ability to wait for a given block height.
+type BlockHeightWaiter interface {
+	WaitForBlockHeight(blockNumber uint64) error
+}
+
+// WaitForChainConfirmation ensures that after receiving specific number of block
+// confirmations the state of the chain is actually as expected. It waits for
+// predefined number of blocks since the start block number provided. After the
+// required block number is reached it performs a check of the chain state with
+// a provided function returning a boolean value.
+func WaitForChainConfirmation(
+	blockHeightWaiter BlockHeightWaiter,
+	startBlockNumber uint64,
+	blockConfirmations uint64,
+	stateCheck func() (bool, error),
+) (bool, error) {
+	blockHeight := startBlockNumber + blockConfirmations
+	logger.Infof("waiting for block [%d] to confirm chain state", blockHeight)
+
+	err := blockHeightWaiter.WaitForBlockHeight(blockHeight)
+	if err != nil {
+		return false, fmt.Errorf("failed to wait for block height: [%v]", err)
+	}
+
+	result, err := stateCheck()
+	if err != nil {
+		return false, fmt.Errorf("failed to get chain state confirmation: [%v]", err)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/574

Added the `WaitForChainConfirmation` function which provides the ability to check the chain state once the chain reaches the given block height.