### PR TITLE
Expose `BalanceAt` method

### DIFF
--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -28,6 +28,12 @@ type EthereumClient interface {
 	bind.ContractBackend
 	ethereum.ChainReader
 	ethereum.TransactionReader
+
+	BalanceAt(
+		ctx context.Context,
+		account common.Address,
+		blockNumber *big.Int,
+	) (*big.Int, error)
 }
 
 // AddressFromHex converts the passed string to a common.Address and returns it,

--- a/pkg/chain/ethereum/ethutil/rate_limiter.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter.go
@@ -335,3 +335,17 @@ func (rl *rateLimiter) TransactionReceipt(
 
 	return rl.EthereumClient.TransactionReceipt(ctx, txHash)
 }
+
+func (rl *rateLimiter) BalanceAt(
+	ctx context.Context,
+	account common.Address,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	err := rl.acquirePermit()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire rate limiter permit: [%v]", err)
+	}
+	defer rl.releasePermit()
+
+	return rl.EthereumClient.BalanceAt(ctx, account, blockNumber)
+}

--- a/pkg/chain/ethereum/ethutil/rate_limiter_test.go
+++ b/pkg/chain/ethereum/ethutil/rate_limiter_test.go
@@ -470,6 +470,15 @@ func (mec *mockEthereumClient) TransactionReceipt(
 	return nil, nil
 }
 
+func (mec *mockEthereumClient) BalanceAt(
+	ctx context.Context,
+	account common.Address,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	mec.mockRequest()
+	return nil, nil
+}
+
 func getTests(
 	client EthereumClient,
 ) map[string]struct{ function func() error } {
@@ -635,6 +644,16 @@ func getTests(
 				_, err := client.TransactionReceipt(
 					context.Background(),
 					common.Hash{},
+				)
+				return err
+			},
+		},
+		"test BalanceAt": {
+			function: func() error {
+				_, err := client.BalanceAt(
+					context.Background(),
+					common.Address{},
+					big.NewInt(0),
 				)
 				return err
 			},


### PR DESCRIPTION
Here we expose the `BalanceAt` method in the `EthereumClient` interface and add it to the rate-limiting wrapper.