### PR TITLE
Subscription dance: backoff, logging, and test coverage

### DIFF
--- a/pkg/chain/ethereum/ethutil/resubscribe.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe.go
@@ -29,7 +29,7 @@ import (
 // goroutine and thus are non-blocking.
 func WithResubscription(
 	backoffMax time.Duration,
-	resubscribeFn event.ResubscribeFunc,
+	subscribeFn event.ResubscribeFunc,
 	alertThreshold time.Duration,
 	thresholdViolatedFn func(time.Duration),
 	subscriptionFailedFn func(error),
@@ -44,7 +44,7 @@ func WithResubscription(
 
 		lastAttempt = now
 
-		sub, err := resubscribeFn(ctx)
+		sub, err := subscribeFn(ctx)
 		if err != nil {
 			go subscriptionFailedFn(err)
 		}

--- a/pkg/chain/ethereum/ethutil/resubscribe.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe.go
@@ -1,0 +1,39 @@
+package ethutil
+
+import (
+	"context"
+	"time"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// WithResubscription wraps the resubscription function to call it repeatedly
+// to keep a subscription established. When subscription is established, it is
+// monitored and in the case of a failure, resubscription is attempted by
+// calling the function again.
+//
+// The mechanism applies backoff between calls to resubscribe function.
+// The time between calls is adapted based on the error rate, but will never
+// exceed backoffMax.
+//
+// The mechanism monitors the time elapsed between resubscription attempts and
+// if it is shorter than the specificed alertThreshold, it calls the alertFn
+// to alarm about potential problems with the stability of the subscription.
+func WithResubscription(
+	backoffMax time.Duration,
+	resubscribeFn event.ResubscribeFunc,
+	alertThreshold time.Duration,
+	alertFn func(),
+) event.Subscription {
+	lastAttempt := time.Time{}
+	wrappedResubscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		now := time.Now()
+		elapsed := now.Sub(lastAttempt)
+		if elapsed < alertThreshold {
+			alertFn()
+		}
+		lastAttempt = now
+		return resubscribeFn(ctx)
+	}
+
+	return event.Resubscribe(backoffMax, wrappedResubscribeFn)
+}

--- a/pkg/chain/ethereum/ethutil/resubscribe.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe.go
@@ -6,33 +6,57 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 )
 
-// WithResubscription wraps the resubscription function to call it repeatedly
-// to keep a subscription established. When subscription is established, it is
-// monitored and in the case of a failure, resubscription is attempted by
-// calling the function again.
+// WithResubscription wraps the subscribe function to call it repeatedly
+// to keep a subscription alive. When a subscription is established, it is
+// monitored and in the case of a failure, resubscribe is attempted by
+// calling the subscribe function again.
 //
-// The mechanism applies backoff between calls to resubscribe function.
+// The mechanism applies backoff between resubscription attempts.
 // The time between calls is adapted based on the error rate, but will never
 // exceed backoffMax.
 //
 // The mechanism monitors the time elapsed between resubscription attempts and
-// if it is shorter than the specificed alertThreshold, it calls the alertFn
-// to alarm about potential problems with the stability of the subscription.
+// if it is shorter than the specificed alertThreshold, it writes the time
+// elapsed between resubscription attempts to the thresholdViolated channel to
+// alarm about potential problems with the stability of the subscription.
+//
+// Every error returned by the wrapped subscription function, is written to
+// subscriptionFailed channel.
+//
+// If the calling code is interested in reading from thresholdViolated and/or
+// subscriptionFailed channel, appropriate readers need to be set up *before*
+// WithResubscription is called.
+//
+// Writes to thresholdViolated and subscriptionFailed channels are non-blocking
+// and are not stopping resubscription attempts.
 func WithResubscription(
 	backoffMax time.Duration,
-	resubscribeFn event.ResubscribeFunc,
+	resubscribeFn event.ResubscribeFunc,	
 	alertThreshold time.Duration,
-	alertFn func(),
+	thresholdViolated chan<- time.Duration,
+	subscriptionFailed chan<- error,
 ) event.Subscription {
 	lastAttempt := time.Time{}
 	wrappedResubscribeFn := func(ctx context.Context) (event.Subscription, error) {
 		now := time.Now()
 		elapsed := now.Sub(lastAttempt)
 		if elapsed < alertThreshold {
-			alertFn()
+			select {
+			case thresholdViolated <- elapsed: 
+			default:
+			}
 		}
+		
 		lastAttempt = now
-		return resubscribeFn(ctx)
+
+		sub, err := resubscribeFn(ctx)
+		if err != nil {
+			select {
+			case subscriptionFailed <- err:
+			default:
+			}
+		}
+		return sub, err
 	}
 
 	return event.Resubscribe(backoffMax, wrappedResubscribeFn)

--- a/pkg/chain/ethereum/ethutil/resubscribe_test.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe_test.go
@@ -52,7 +52,7 @@ func TestEmitOriginalError(t *testing.T) {
 	// That failure should refer the original error.
 	err := <-subscriptionFailed
 	if err.Error() != expectedFailMessage {
-		t.Fatalf(
+		t.Errorf(
 			"unexpected subscription error message\nexpected: [%v]\nactual:   [%v]",
 			expectedFailMessage,
 			err.Error(),
@@ -99,7 +99,7 @@ func TestResubscribeAboveThreshold(t *testing.T) {
 	// in a time shorter than 150ms one after another.
 	violationCount := len(thresholdViolated)
 	if violationCount != 0 {
-		t.Fatalf(
+		t.Errorf(
 			"threshold violation reported [%v] times, expected none",
 			violationCount,
 		)
@@ -111,7 +111,7 @@ func TestResubscribeAboveThreshold(t *testing.T) {
 	// successful and had not to be retried.
 	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
 	if resubscribeFnCalls != expectedResubscriptionCalls {
-		t.Fatalf(
+		t.Errorf(
 			"resubscription called [%v] times, expected [%v]",
 			resubscribeFnCalls,
 			expectedResubscriptionCalls,
@@ -121,7 +121,7 @@ func TestResubscribeAboveThreshold(t *testing.T) {
 	// Expect all subscription failures to be reported.
 	subscriptionFailCount := len(subscriptionFailed)
 	if subscriptionFailCount != plannedSubscriptionFailures {
-		t.Fatalf(
+		t.Errorf(
 			"subscription failure reported [%v] times, expected [%v]",
 			subscriptionFailCount,
 			plannedSubscriptionFailures,
@@ -171,7 +171,7 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 	// resubscription attempts.
 	violationCount := len(thresholdViolated)
 	if violationCount != plannedSubscriptionFailures {
-		t.Fatalf(
+		t.Errorf(
 			"threshold violation reported [%v] times, expected [%v]",
 			violationCount,
 			plannedSubscriptionFailures,
@@ -184,7 +184,7 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 	for i := 0; i < violationCount; i++ {
 		violation := <-thresholdViolated
 		if violation < elapsedBetweenFailures {
-			t.Fatalf(
+			t.Errorf(
 				"violation reported should be longer than the time elapsed "+
 					"between failures; is: [%v] and should be longer than [%v]",
 				violation,
@@ -192,7 +192,7 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 			)
 		}
 		if violation > alertThreshold {
-			t.Fatalf(
+			t.Errorf(
 				"violation reported should be shorter than the alert threshold; "+
 					"; is: [%v] and should be shorter than [%v]",
 				violation,
@@ -207,7 +207,7 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 	// successful and had not to be retried.
 	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
 	if resubscribeFnCalls != expectedResubscriptionCalls {
-		t.Fatalf(
+		t.Errorf(
 			"resubscription called [%v] times, expected [%v]",
 			resubscribeFnCalls,
 			expectedResubscriptionCalls,
@@ -217,7 +217,7 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 	// Expect all subscription failures to be reported.
 	subscriptionFailCount := len(subscriptionFailed)
 	if subscriptionFailCount != plannedSubscriptionFailures {
-		t.Fatalf(
+		t.Errorf(
 			"subscription failure reported [%v] times, expected [%v]",
 			subscriptionFailCount,
 			plannedSubscriptionFailures,
@@ -280,7 +280,7 @@ func TestDoNotBlockOnChannelWrites(t *testing.T) {
 	// blocked by the lack of channel receivers on non-buffered channels.
 	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
 	if resubscribeFnCalls != expectedResubscriptionCalls {
-		t.Fatalf(
+		t.Errorf(
 			"resubscription called [%v] times, expected [%v]",
 			resubscribeFnCalls,
 			expectedResubscriptionCalls,

--- a/pkg/chain/ethereum/ethutil/resubscribe_test.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe_test.go
@@ -1,0 +1,121 @@
+package ethutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func TestResubscribeAboveThreshold(t *testing.T) {
+	backoffMax := 100 * time.Millisecond
+	alertThreshold := 100 * time.Millisecond
+
+	alertFnCalls := 0
+	alertFn := func() {
+		alertFnCalls++
+	}
+
+	subscriptionFailures := 3
+	resubscribeFnCalls := 0
+	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		resubscribeFnCalls++
+		time.Sleep(150 * time.Millisecond) // 150 > 100, above alert threshold
+		if resubscribeFnCalls <= subscriptionFailures {
+			return nil, fmt.Errorf("this is the way")
+		}
+		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
+			return nil
+		})
+		return delegate, nil
+	}
+
+	subscription := WithResubscription(
+		backoffMax,
+		resubscribeFn,
+		alertThreshold,
+		alertFn,
+	)
+	<-subscription.Err()
+
+	// No calls to alertFn expected. Alert threshold is set to 100ms and no
+	// there were no resubscription attempts in a time shorter than 150ms one
+	// after another.
+	if alertFnCalls != 0 {
+		t.Fatalf("alert triggered [%v] times, expected none", alertFnCalls)
+	}
+
+	// Subscription failed `subscriptionFailures` times and resubscription
+	// function should be called `subscriptionFailures + 1` times - one time
+	// for each failure and one time at the end - that subscription was
+	// successful and had not to be retried.
+	expectedResubscriptionCalls := subscriptionFailures + 1
+	if resubscribeFnCalls != expectedResubscriptionCalls {
+		t.Fatalf(
+			"resubscription called [%v] times, expected [%v]",
+			resubscribeFnCalls,
+			expectedResubscriptionCalls,
+		)
+	}
+}
+
+func TestResubscribeBelowThreshold(t *testing.T) {
+	backoffMax := 50 * time.Millisecond
+	alertThreshold := 100 * time.Millisecond
+
+	alertFnCalls := 0
+	alertFn := func() {
+		alertFnCalls++
+	}
+
+	subscriptionFailures := 5
+	resubscribeFnCalls := 0
+	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		resubscribeFnCalls++
+		time.Sleep(50 * time.Millisecond) // 50 < 100, below alert threshold
+		if resubscribeFnCalls <= subscriptionFailures {
+			return nil, fmt.Errorf("i have spoken")
+		}
+		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
+			return nil
+		})
+		return delegate, nil
+	}
+
+	subscription := WithResubscription(
+		backoffMax,
+		resubscribeFn,
+		alertThreshold,
+		alertFn,
+	)
+	<-subscription.Err()
+
+	fmt.Printf("resubscribe count = [%v]\n", resubscribeFnCalls)
+	// Alert function should be called for each subscription failure if the time
+	// between the previous resubscription was shorter than the threshold.
+	// In this test, alert threshold is set to 100ms and delays between failures
+	// are just 50ms.
+	expectedAlertFnCalls := subscriptionFailures
+	if alertFnCalls != expectedAlertFnCalls {
+		t.Fatalf(
+			"alert triggered [%v] times, expected [%v]",
+			alertFnCalls,
+			expectedAlertFnCalls,
+		)
+	}
+
+	// Subscription failed `subscriptionFailures` times and resubscription
+	// function should be called `subscriptionFailures + 1` times - one time
+	// for each failure and one time at the end - that subscription was
+	// successful and had not to be retried.
+	expectedResubscriptionCalls := subscriptionFailures + 1
+	if resubscribeFnCalls != expectedResubscriptionCalls {
+		t.Fatalf(
+			"resubscription called [%v] times, expected [%v]",
+			resubscribeFnCalls,
+			expectedResubscriptionCalls,
+		)
+	}
+}

--- a/pkg/chain/ethereum/ethutil/resubscribe_test.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe_test.go
@@ -14,10 +14,11 @@ func TestEmitOriginalError(t *testing.T) {
 	alertThreshold := 100 * time.Millisecond
 
 	failedOnce := false
+	expectedFailMessage := "wherever I go, he goes"
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
 		if !failedOnce {
 			failedOnce = true
-			return nil, fmt.Errorf("wherever I go, he goes")
+			return nil, fmt.Errorf(expectedFailMessage)
 		}
 		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
 			return nil
@@ -49,7 +50,6 @@ func TestEmitOriginalError(t *testing.T) {
 	}
 
 	// That failure should refer the original error.
-	expectedFailMessage := "wherever I go, he goes"
 	err := <-subscriptionFailed
 	if err.Error() != expectedFailMessage {
 		t.Fatalf(

--- a/pkg/chain/ethereum/ethutil/resubscribe_test.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe_test.go
@@ -9,21 +9,66 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 )
 
+func TestEmitOriginalError(t *testing.T) {
+	backoffMax := 100 * time.Millisecond
+	alertThreshold := 100 * time.Millisecond
+
+	failedOnce := false
+	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		if !failedOnce {
+			failedOnce = true
+			return nil, fmt.Errorf("wherever I go, he goes")
+		}
+		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
+			return nil
+		})
+		return delegate, nil
+	}
+
+	thresholdViolated := make(chan time.Duration, 10)
+	subscriptionFailed := make(chan error, 10)
+	subscription := WithResubscription(
+		backoffMax,
+		resubscribeFn,
+		alertThreshold,
+		thresholdViolated,
+		subscriptionFailed,
+	)
+	<-subscription.Err()
+
+	// Subscription failed one time so there should be one error in the channel.
+	subscriptionFailCount := len(subscriptionFailed)
+	if subscriptionFailCount != 1 {
+		t.Fatalf(
+			"subscription failure reported [%v] times, expected [1]",
+			subscriptionFailCount,
+		)
+	}
+
+	// That failure should refer the original error.
+	expectedFailMessage := "wherever I go, he goes"
+	err := <-subscriptionFailed
+	if err.Error() != expectedFailMessage {
+		t.Fatalf(
+			"unexpected subscription error message\nexpected: [%v]\nactual:   [%v]",
+			expectedFailMessage,
+			err.Error(),
+		)
+	}
+}
+
 func TestResubscribeAboveThreshold(t *testing.T) {
 	backoffMax := 100 * time.Millisecond
 	alertThreshold := 100 * time.Millisecond
 
-	alertFnCalls := 0
-	alertFn := func() {
-		alertFnCalls++
-	}
+	plannedSubscriptionFailures := 3
+	elapsedBetweenFailures := 150 * time.Millisecond
 
-	subscriptionFailures := 3
 	resubscribeFnCalls := 0
 	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
 		resubscribeFnCalls++
-		time.Sleep(150 * time.Millisecond) // 150 > 100, above alert threshold
-		if resubscribeFnCalls <= subscriptionFailures {
+		time.Sleep(elapsedBetweenFailures) // 150ms > 100ms, above alert threshold
+		if resubscribeFnCalls <= plannedSubscriptionFailures {
 			return nil, fmt.Errorf("this is the way")
 		}
 		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
@@ -32,31 +77,48 @@ func TestResubscribeAboveThreshold(t *testing.T) {
 		return delegate, nil
 	}
 
+	thresholdViolated := make(chan time.Duration, 10)
+	subscriptionFailed := make(chan error, 10)
 	subscription := WithResubscription(
 		backoffMax,
 		resubscribeFn,
 		alertThreshold,
-		alertFn,
+		thresholdViolated,
+		subscriptionFailed,
 	)
 	<-subscription.Err()
 
-	// No calls to alertFn expected. Alert threshold is set to 100ms and no
-	// there were no resubscription attempts in a time shorter than 150ms one
-	// after another.
-	if alertFnCalls != 0 {
-		t.Fatalf("alert triggered [%v] times, expected none", alertFnCalls)
+	// Nothing expected in thresholdViolated channel.
+	// Alert threshold is set to 100ms and there were no resubscription attempts
+	// in a time shorter than 150ms one after another.
+	violationCount := len(thresholdViolated)
+	if violationCount != 0 {
+		t.Fatalf(
+			"threshold violation reported [%v] times, expected none",
+			violationCount,
+		)
 	}
 
-	// Subscription failed `subscriptionFailures` times and resubscription
-	// function should be called `subscriptionFailures + 1` times - one time
+	// Subscription failed plannedSubscriptionFailures times and resubscription
+	// function should be called plannedSubscriptionFailures + 1 times. One time
 	// for each failure and one time at the end - that subscription was
 	// successful and had not to be retried.
-	expectedResubscriptionCalls := subscriptionFailures + 1
+	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
 	if resubscribeFnCalls != expectedResubscriptionCalls {
 		t.Fatalf(
 			"resubscription called [%v] times, expected [%v]",
 			resubscribeFnCalls,
 			expectedResubscriptionCalls,
+		)
+	}
+
+	// Expect all subscription failures to be reported.
+	subscriptionFailCount := len(subscriptionFailed)
+	if subscriptionFailCount != plannedSubscriptionFailures {
+		t.Fatalf(
+			"subscription failure reported [%v] times, expected [%v]",
+			subscriptionFailCount,
+			plannedSubscriptionFailures,
 		)
 	}
 }
@@ -65,17 +127,14 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 	backoffMax := 50 * time.Millisecond
 	alertThreshold := 100 * time.Millisecond
 
-	alertFnCalls := 0
-	alertFn := func() {
-		alertFnCalls++
-	}
+	plannedSubscriptionFailures := 5
+	elapsedBetweenFailures := 50 * time.Millisecond
 
-	subscriptionFailures := 5
 	resubscribeFnCalls := 0
 	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
 		resubscribeFnCalls++
-		time.Sleep(50 * time.Millisecond) // 50 < 100, below alert threshold
-		if resubscribeFnCalls <= subscriptionFailures {
+		time.Sleep(elapsedBetweenFailures) // 50ms < 100ms, below alert threshold
+		if resubscribeFnCalls <= plannedSubscriptionFailures {
 			return nil, fmt.Errorf("i have spoken")
 		}
 		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
@@ -84,33 +143,118 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 		return delegate, nil
 	}
 
+	thresholdViolated := make(chan time.Duration, 10)
+	subscriptionFailed := make(chan error, 10)
 	subscription := WithResubscription(
 		backoffMax,
 		resubscribeFn,
 		alertThreshold,
-		alertFn,
+		thresholdViolated,
+		subscriptionFailed,
 	)
 	<-subscription.Err()
 
-	fmt.Printf("resubscribe count = [%v]\n", resubscribeFnCalls)
-	// Alert function should be called for each subscription failure if the time
-	// between the previous resubscription was shorter than the threshold.
+	// Threshold violaton should be reported for each subscription failure if
+	// the time elapsed since the previous resubscription was shorter than the
+	// threshold.
 	// In this test, alert threshold is set to 100ms and delays between failures
-	// are just 50ms.
-	expectedAlertFnCalls := subscriptionFailures
-	if alertFnCalls != expectedAlertFnCalls {
+	// are just 50ms. Thus, we expect the same number of threshold violations as
+	// resubscription attempts.
+	violationCount := len(thresholdViolated)
+	if violationCount != plannedSubscriptionFailures {
 		t.Fatalf(
-			"alert triggered [%v] times, expected [%v]",
-			alertFnCalls,
-			expectedAlertFnCalls,
+			"threshold violation reported [%v] times, expected [%v]",
+			violationCount,
+			plannedSubscriptionFailures,
 		)
 	}
 
-	// Subscription failed `subscriptionFailures` times and resubscription
-	// function should be called `subscriptionFailures + 1` times - one time
+	// All violations reported should have correct values - all of them should
+	// be longer than the time elapsed between failures and shorter than the
+	// alert threshold. It is not possible to assert on a precise value.
+	for i := 0; i < violationCount; i++ {
+		violation := <-thresholdViolated
+		if violation < elapsedBetweenFailures {
+			t.Fatalf(
+				"violation reported should be longer than the time elapsed "+
+					"between failures; is: [%v] and should be longer than [%v]",
+				violation,
+				elapsedBetweenFailures,
+			)
+		}
+		if violation > alertThreshold {
+			t.Fatalf(
+				"violation reported should be shorter than the alert threshold; "+
+					"; is: [%v] and should be shorter than [%v]",
+				violation,
+				alertThreshold,
+			)
+		}
+	}
+
+	// Subscription failed plannedSubscriptionFailures times and resubscription
+	// function should be called plannedSubscriptionFailures + 1 times. One time
 	// for each failure and one time at the end - that subscription was
 	// successful and had not to be retried.
-	expectedResubscriptionCalls := subscriptionFailures + 1
+	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
+	if resubscribeFnCalls != expectedResubscriptionCalls {
+		t.Fatalf(
+			"resubscription called [%v] times, expected [%v]",
+			resubscribeFnCalls,
+			expectedResubscriptionCalls,
+		)
+	}
+
+	// Expect all subscription failures to be reported.
+	subscriptionFailCount := len(subscriptionFailed)
+	if subscriptionFailCount != plannedSubscriptionFailures {
+		t.Fatalf(
+			"subscription failure reported [%v] times, expected [%v]",
+			subscriptionFailCount,
+			plannedSubscriptionFailures,
+		)
+	}
+}
+
+func TestDoNotBlockOnChannelWrites(t *testing.T) {
+	backoffMax := 50 * time.Millisecond
+	alertThreshold := 100 * time.Millisecond
+
+	plannedSubscriptionFailures := 5
+	elapsedBetweenFailures := 10 * time.Millisecond
+
+	resubscribeFnCalls := 0
+	resubscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		resubscribeFnCalls++
+		time.Sleep(elapsedBetweenFailures) // 10ms < 100ms, below alert threshold
+		if resubscribeFnCalls <= plannedSubscriptionFailures {
+			return nil, fmt.Errorf("Groku?")
+		}
+		delegate := event.NewSubscription(func(unsubscribed <-chan struct{}) error {
+			return nil
+		})
+		return delegate, nil
+	}
+
+	// Non-buffered channels with no receivers
+	thresholdViolated := make(chan time.Duration)
+	subscriptionFailed := make(chan error)
+
+	subscription := WithResubscription(
+		backoffMax,
+		resubscribeFn,
+		alertThreshold,
+		thresholdViolated,
+		subscriptionFailed,
+	)
+	<-subscription.Err()
+
+	// Subscription failed plannedSubscriptionFailures times and resubscription
+	// function should be called plannedSubscriptionFailures + 1 times. One time
+	// for each failure and one time at the end - that subscription was
+	// successful and had not to be retried. No resubscription attempt should be
+	// blocked by the lack of channel receivers on non-buffered channels.
+	expectedResubscriptionCalls := plannedSubscriptionFailures + 1
 	if resubscribeFnCalls != expectedResubscriptionCalls {
 		t.Fatalf(
 			"resubscription called [%v] times, expected [%v]",

--- a/pkg/chain/ethereum/ethutil/resubscribe_test.go
+++ b/pkg/chain/ethereum/ethutil/resubscribe_test.go
@@ -25,6 +25,9 @@ func TestEmitOriginalError(t *testing.T) {
 		return delegate, nil
 	}
 
+	// Using buffered channels to do not block writes.
+	// There should never be a need to write more to those channels if the code
+	// under the test works as expected.
 	thresholdViolated := make(chan time.Duration, 10)
 	subscriptionFailed := make(chan error, 10)
 	subscription := WithResubscription(
@@ -77,6 +80,9 @@ func TestResubscribeAboveThreshold(t *testing.T) {
 		return delegate, nil
 	}
 
+	// Using buffered channels to do not block writes.
+	// There should never be a need to write more to those channels if the code
+	// under the test works as expected.
 	thresholdViolated := make(chan time.Duration, 10)
 	subscriptionFailed := make(chan error, 10)
 	subscription := WithResubscription(
@@ -143,6 +149,9 @@ func TestResubscribeBelowThreshold(t *testing.T) {
 		return delegate, nil
 	}
 
+	// Using buffered channels to do not block writes.
+	// There should never be a need to write more to those channels if the code
+	// under the test works as expected.
 	thresholdViolated := make(chan time.Duration, 10)
 	subscriptionFailed := make(chan error, 10)
 	subscription := WithResubscription(

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -37,7 +37,7 @@ const (
     // subscription required before the subscription failure happens and
     // resubscription follows so that the resubscription does not emit an error
     // to the logs alerting about potential problems with Ethereum client.
-    {{.ShortVar}}SubscriptionAlertThreshold = 5 * time.Minute
+    {{.ShortVar}}SubscriptionAlertThreshold = 15 * time.Minute
 )
 
 type {{.Class}} struct {

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -25,6 +25,21 @@ import (
 // included or excluded from logging at startup by name.
 var {{.ShortVar}}Logger = log.Logger("keep-contract-{{.Class}}")
 
+const (
+    // Maximum backoff time between event resubscription attempts.
+    {{.ShortVar}}SubscriptionBackoffMax = 2 * time.Minute
+
+    // Threshold below which event resubscription emits an error to the logs.
+    // WS connection can be dropped at any moment and event resubscription will
+    // follow. However, if WS connection for event subscription is getting
+    // dropped too often, it may indicate something is wrong with Ethereum
+    // client. This constant defines the minimum lifetime of an event
+    // subscription required before the subscription failure happens and
+    // resubscription follows so that the resubscription does not emit an error
+    // to the logs alerting about potential problems with Ethereum client.
+    {{.ShortVar}}SubscriptionAlertThreshold = 5 * time.Minute
+)
+
 type {{.Class}} struct {
 	contract           *abi.{{.AbiClass}}
 	contractAddress    common.Address

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -66,26 +66,30 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 		)
 	}
 
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		{{$logger}}.Errorf(
+			"subscription to event {{$event.CapsName}} had to be "+
+				"retried [%v] since the last attempt; please inspect "+
+				"Ethereum client connectivity",
+				elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		{{$logger}}.Errorf(
+			"subscription to event {{$event.CapsName}} failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+				err,
+		)
+	}
+
 	sub := ethutil.WithResubscription(
 		{{$contract.ShortVar}}SubscriptionBackoffMax,
 		subscribeFn,
 		{{$contract.ShortVar}}SubscriptionAlertThreshold,
-		func(elapsed time.Duration) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} had to be "+
-						"retried [%v] since the last attempt; please inspect "+
-						"Ethereum client connectivity",
-					elapsed,
-				)
-		},
-		func(err error) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} failed "+
-						"with error: [%v]; resubscription attempt will be "+
-						"performed",
-					err,
-				)
-		},
+		thresholdViolatedFn,
+		subscriptionFailedFn,
 	)
 
 	return subscription.NewEventSubscription(func() {

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -70,7 +70,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 		{{$logger}}.Errorf(
 			"subscription to event {{$event.CapsName}} had to be "+
 				"retried [%v] since the last attempt; please inspect "+
-				"Ethereum client connectivity",
+				"Ethereum connectivity",
 				elapsed,
 		)
 	}

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -41,7 +41,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 ) (subscription.EventSubscription) {
 	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	// TODO: Watch* function will soon accept channel as a parameter instead
 	// of the callback. This loop will be eliminated then.
@@ -94,7 +94,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -37,119 +37,62 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events
 
 func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 	success {{$contract.FullVar}}{{$event.CapsName}}Func,
-	fail func(err error) error,
 	{{$event.IndexedFilterDeclarations -}}
-) (subscription.EventSubscription, error) {
-    errorChan := make(chan error)
-    unsubscribeChan := make(chan struct{})
+) (subscription.EventSubscription) {
+	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
+	thresholdViolated := make(chan time.Duration)
+	subscriptionFailed := make(chan error)
 
-    // Delay which must be preserved before a new resubscription attempt.
-    // There is no sense to resubscribe immediately after the fail of current
-    // subscription because the publisher must have some time to recover.
-    retryDelay := 5 * time.Second
+	ctx, cancel := context.WithCancel(context.Background())
 
-    watch := func() {
-    	failCallback := func(err error) error {
-    		fail(err)
-    		errorChan <- err // trigger resubscription signal
-    		return err
-    	}
-
-    	subscription, err := {{$contract.ShortVar}}.subscribe{{$event.CapsName}}(
-    	    success,
-    	    failCallback,
-    	    {{$event.IndexedFilters}}
-    	)
-    	if err != nil {
-    		errorChan <- err // trigger resubscription signal
-    		return
-    	}
-
-    	// wait for unsubscription signal
-    	<-unsubscribeChan
-    	subscription.Unsubscribe()
-    }
-
-    // trigger the resubscriber goroutine
-    go func() {
-    	go watch() // trigger first subscription
-
-    	for {
-    		select {
-    		case <-errorChan:
-    		    {{$logger}}.Warning(
-                    "subscription to event {{$event.CapsName}} terminated with error; " +
-                        "resubscription attempt will be performed after the retry delay",
-                )
-    			time.Sleep(retryDelay)
-    			go watch()
-    		case <-unsubscribeChan:
-    			// shutdown the resubscriber goroutine on unsubscribe signal
-    			return
-    		}
-    	}
-    }()
-
-    // closing the unsubscribeChan will trigger a unsubscribe signal and
-    // run unsubscription for all subscription instances
-    unsubscribeCallback := func() {
-    	close(unsubscribeChan)
-    }
-
-    return subscription.NewEventSubscription(unsubscribeCallback), nil
-}
-
-func ({{$contract.ShortVar}} *{{$contract.Class}}) subscribe{{$event.CapsName}}(
-	success {{$contract.FullVar}}{{$event.CapsName}}Func,
-	fail func(err error) error,
-	{{$event.IndexedFilterDeclarations -}}
-) (subscription.EventSubscription, error) {
-	eventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-	eventSubscription, err := {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
-		nil,
-		eventChan,
-		{{$event.IndexedFilters}}
-	)
-	if err != nil {
-		close(eventChan)
-		return eventSubscription, fmt.Errorf(
-			"error creating watch for {{$event.CapsName}} events: [%v]",
-			err,
-		)
-	}
-
-	var subscriptionMutex = &sync.Mutex{}
 
 	go func() {
 		for {
 			select {
-			case event, subscribed := <-eventChan:
-				subscriptionMutex.Lock()
-				// if eventChan has been closed, it means we have unsubscribed
-				if !subscribed {
-					subscriptionMutex.Unlock()
-					return
-				}
+			case <-ctx.Done():
+				return
+			case event := <-eventOccurred:
 				success(
                     {{$event.ParamExtractors}}
 				)
-				subscriptionMutex.Unlock()
-			case ee := <-eventSubscription.Err():
-				fail(ee)
-				return
+			case violation := <-thresholdViolated:
+				{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} had to be "+
+						"retried [%v] since the last attempt; please inspect "+
+						"Ethereum client connectivity",
+					violation,
+				)
+			case err := <-subscriptionFailed:
+				{{$logger}}.Warningf(
+					"subscription to event {{$event.CapsName}} failed "+
+						"with error: [%v]; resubscription attempt will be "+
+						"performed",
+					err,
+				)
 			}
 		}
 	}()
 
-	unsubscribeCallback := func() {
-		subscriptionMutex.Lock()
-		defer subscriptionMutex.Unlock()
-
-		eventSubscription.Unsubscribe()
-		close(eventChan)
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
+			&bind.WatchOpts{Context: ctx},
+			eventOccurred,
+			{{$event.IndexedFilters}}
+		)
 	}
 
-	return subscription.NewEventSubscription(unsubscribeCallback), nil
+	sub := ethutil.WithResubscription(
+		{{$contract.ShortVar}}SubscriptionBackoffMax,
+		subscribeFn,
+		{{$contract.ShortVar}}SubscriptionAlertThreshold,
+		thresholdViolated,
+		subscriptionFailed,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancel()
+	})
 }
 
 {{- end -}}

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -40,12 +40,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 	{{$event.IndexedFilterDeclarations -}}
 ) (subscription.EventSubscription) {
 	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-	thresholdViolated := make(chan time.Duration)
-	subscriptionFailed := make(chan error)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-
+	// TODO: Watch* function will soon accept channel as a parameter instead
+	// of the callback. This loop will be eliminated then.
 	go func() {
 		for {
 			select {
@@ -54,20 +53,6 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 			case event := <-eventOccurred:
 				success(
                     {{$event.ParamExtractors}}
-				)
-			case violation := <-thresholdViolated:
-				{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} had to be "+
-						"retried [%v] since the last attempt; please inspect "+
-						"Ethereum client connectivity",
-					violation,
-				)
-			case err := <-subscriptionFailed:
-				{{$logger}}.Warningf(
-					"subscription to event {{$event.CapsName}} failed "+
-						"with error: [%v]; resubscription attempt will be "+
-						"performed",
-					err,
 				)
 			}
 		}
@@ -85,8 +70,22 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 		{{$contract.ShortVar}}SubscriptionBackoffMax,
 		subscribeFn,
 		{{$contract.ShortVar}}SubscriptionAlertThreshold,
-		thresholdViolated,
-		subscriptionFailed,
+		func(elapsed time.Duration) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} had to be "+
+						"retried [%v] since the last attempt; please inspect "+
+						"Ethereum client connectivity",
+					elapsed,
+				)
+		},
+		func(err error) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} failed "+
+						"with error: [%v]; resubscription attempt will be "+
+						"performed",
+					err,
+				)
+		},
 	)
 
 	return subscription.NewEventSubscription(func() {

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -69,7 +69,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		{{$logger}}.Errorf(
 			"subscription to event {{$event.CapsName}} had to be "+
-				"retried [%v] since the last attempt; please inspect "+
+				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 				elapsed,
 		)

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -73,7 +73,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 		{{$logger}}.Errorf(
 			"subscription to event {{$event.CapsName}} had to be "+
 				"retried [%v] since the last attempt; please inspect "+
-				"Ethereum client connectivity",
+				"Ethereum connectivity",
 				elapsed,
 		)
 	}

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -72,7 +72,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		{{$logger}}.Errorf(
 			"subscription to event {{$event.CapsName}} had to be "+
-				"retried [%v] since the last attempt; please inspect "+
+				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 				elapsed,
 		)

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -66,10 +66,9 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 					violation,
 				)
 			case err := <-subscriptionFailed:
-				{{$logger}}.Warningf(
-					"subscription to event {{$event.CapsName}} failed "+
-						"with error: [%v]; resubscription attempt will be "+
-						"performed",
+				{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} failed: [%v]; "+
+						"resubscription attempt will be performed",
 					err,
 				)
 			}

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -44,7 +44,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 ) (subscription.EventSubscription) {
 	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	// TODO: Watch* function will soon accept channel as a parameter instead
 	// of the callback. This loop will be eliminated then.
@@ -97,7 +97,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
 
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -28,6 +28,21 @@ import (
 // included or excluded from logging at startup by name.
 var {{.ShortVar}}Logger = log.Logger("keep-contract-{{.Class}}")
 
+const (
+    // Maximum backoff time between event resubscription attempts.
+    {{.ShortVar}}SubscriptionBackoffMax = 2 * time.Minute
+
+    // Threshold below which event resubscription emits an error to the logs.
+    // WS connection can be dropped at any moment and event resubscription will
+    // follow. However, if WS connection for event subscription is getting
+    // dropped too often, it may indicate something is wrong with Ethereum
+    // client. This constant defines the minimum lifetime of an event
+    // subscription required before the subscription failure happens and
+    // resubscription follows so that the resubscription does not emit an error
+    // to the logs alerting about potential problems with Ethereum client.
+    {{.ShortVar}}SubscriptionAlertThreshold = 5 * time.Minute
+)
+
 type {{.Class}} struct {
 	contract           *abi.{{.AbiClass}}
 	contractAddress    common.Address

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -40,7 +40,7 @@ const (
     // subscription required before the subscription failure happens and
     // resubscription follows so that the resubscription does not emit an error
     // to the logs alerting about potential problems with Ethereum client.
-    {{.ShortVar}}SubscriptionAlertThreshold = 5 * time.Minute
+    {{.ShortVar}}SubscriptionAlertThreshold = 15 * time.Minute
 )
 
 type {{.Class}} struct {


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-ecdsa/issues/680

This PR is the first one in the series of PRs refactoring Ethereum event subscriptions mechanism I plan to open in the next few days.

You can see it in action here: https://github.com/keep-network/keep-ecdsa/pull/663.

So far resubscription logging was implemented in contract binding templates. There were three problems with that mechanism:
1. No resubscribe backoff. Each failed subscription was retried 5 seconds after it failed. For many individual subscriptions ECDSA client is opening, a massive retry with no backoff could be interpreted as misbehavior by a third party Ethereum provider and further attempts could be completely blocked. Some operators experienced it with Alchemy.
2. All the logging was on the warning level. With the lack of backoff mentioned in the previous point, this could produce a deadly mixture - keep client could be trying to reconnect for a long time, Ethereum client could be rejecting those attempts interpreting them as DoS/misbehavior, and operator received only warnings with no single error.
3. Lack of test coverage for the resubscription mechanism. All the subscription code was placed in templates used to generate Go contract bindings and was very hard - if possible at all - to test.

Here we address all those problems.

Instead of implementing resubscriptions on our side, we wrap the code from `github.com/ethereum/go-ethereum/event` with some additional logging logic. This code is used from contract templates to keep the subscription alive. We lean on `go-ethereum` to do those resubscriptions right and we cover our logic addition in unit tests on our side.

The code from `go-ethereum` implements backoffs, increasing the delay twice until it reaches the maximum backoff time which is set in our bindings to 2 minutes.

The new code in `ethutil` wrapping `go-ethereum`'s resubscriber, allows to log an error if the subscription is dropped too often which may indicate problems with Ethereum client. The threshold is set to 15 minutes.
