### PR TITLE
New Ethereum event subscription API, background event pull loop

### DIFF
--- a/pkg/chain/ethereum/ethutil/subscribe_opts.go
+++ b/pkg/chain/ethereum/ethutil/subscribe_opts.go
@@ -3,11 +3,11 @@ package ethutil
 import "time"
 
 const (
-	// DefaultSubscribeOptsTickDuration is the default duration with which
+	// DefaultSubscribeOptsTick is the default duration with which
 	// past events are pulled from the chain by the subscription monitoring
 	// mechanism if no other value is provided in SubscribeOpts when creating
 	// the subscription.
-	DefaultSubscribeOptsTickDuration = 15 * time.Minute
+	DefaultSubscribeOptsTick = 15 * time.Minute
 
 	// DefaultSubscribeOptsBlocksBack is the default number of past blocks
 	// pulled from the chain by the subscription monitoring mechanism if no
@@ -19,12 +19,12 @@ const (
 // when creating Ethereum event subscription.
 type SubscribeOpts struct {
 
-	// TickDuration is the duration with which subscription monitoring mechanism
+	// Tick is the duration with which subscription monitoring mechanism
 	// pulls events from the chain. This mechanism is an additional process
 	// next to a regular watchLogs subscription making sure no events are lost
 	// even in case the regular subscription missed them because of, for
 	// example, connectivity problems.
-	TickDuration time.Duration
+	Tick time.Duration
 
 	// BlocksBack is the number of past blocks subscription monitoring mechanism
 	// takes into consideration when pulling past events from the chain.

--- a/pkg/chain/ethereum/ethutil/subscribe_opts.go
+++ b/pkg/chain/ethereum/ethutil/subscribe_opts.go
@@ -3,11 +3,34 @@ package ethutil
 import "time"
 
 const (
+	// DefaultSubscribeOptsTickDuration is the default duration with which
+	// past events are pulled from the chain by the subscription monitoring
+	// mechanism if no other value is provided in SubscribeOpts when creating
+	// the subscription.
 	DefaultSubscribeOptsTickDuration = 15 * time.Minute
-	DefaultSubscribeOptsBlocksBack   = 100
+
+	// DefaultSubscribeOptsBlocksBack is the default number of past blocks
+	// pulled from the chain by the subscription monitoring mechanism if no
+	// other value is provided in SubscribeOpts when creating the subscription.
+	DefaultSubscribeOptsBlocksBack = 100
 )
 
+// SubscribeOpts specifies optional configuration options that can be passed
+// when creating Ethereum event subscription.
 type SubscribeOpts struct {
+
+	// TickDuration is the duration with which subscription monitoring mechanism
+	// pulls events from the chain. This mechanism is an additional process
+	// next to a regular watchLogs subscription making sure no events are lost
+	// even in case the regular subscription missed them because of, for
+	// example, connectivity problems.
 	TickDuration time.Duration
-	BlocksBack   uint64
+
+	// BlocksBack is the number of past blocks subscription monitoring mechanism
+	// takes into consideration when pulling past events from the chain.
+	// This event pull mechanism is an additional process next to a regular
+	// watchLogs subscription making sure no events are lost even in case the
+	// regular subscription missed them because of, for example, connectivity
+	// problems.
+	BlocksBack uint64
 }

--- a/pkg/chain/ethereum/ethutil/subscribe_opts.go
+++ b/pkg/chain/ethereum/ethutil/subscribe_opts.go
@@ -9,10 +9,10 @@ const (
 	// the subscription.
 	DefaultSubscribeOptsTick = 15 * time.Minute
 
-	// DefaultSubscribeOptsBlocksBack is the default number of past blocks
+	// DefaultSubscribeOptsPastBlocks is the default number of past blocks
 	// pulled from the chain by the subscription monitoring mechanism if no
 	// other value is provided in SubscribeOpts when creating the subscription.
-	DefaultSubscribeOptsBlocksBack = 100
+	DefaultSubscribeOptsPastBlocks = 100
 )
 
 // SubscribeOpts specifies optional configuration options that can be passed
@@ -26,11 +26,11 @@ type SubscribeOpts struct {
 	// example, connectivity problems.
 	Tick time.Duration
 
-	// BlocksBack is the number of past blocks subscription monitoring mechanism
+	// PastBlocks is the number of past blocks subscription monitoring mechanism
 	// takes into consideration when pulling past events from the chain.
 	// This event pull mechanism is an additional process next to a regular
 	// watchLogs subscription making sure no events are lost even in case the
 	// regular subscription missed them because of, for example, connectivity
 	// problems.
-	BlocksBack uint64
+	PastBlocks uint64
 }

--- a/pkg/chain/ethereum/ethutil/subscribe_opts.go
+++ b/pkg/chain/ethereum/ethutil/subscribe_opts.go
@@ -1,0 +1,13 @@
+package ethutil
+
+import "time"
+
+const (
+	DefaultSubscribeOptsTickDuration = 15 * time.Minute
+	DefaultSubscribeOptsBlocksBack   = 100
+)
+
+type SubscribeOpts struct {
+	TickDuration time.Duration
+	BlocksBack   uint64
+}

--- a/pkg/chain/ethereum/ethutil/subscribe_opts.go
+++ b/pkg/chain/ethereum/ethutil/subscribe_opts.go
@@ -13,6 +13,22 @@ const (
 	// pulled from the chain by the subscription monitoring mechanism if no
 	// other value is provided in SubscribeOpts when creating the subscription.
 	DefaultSubscribeOptsPastBlocks = 100
+
+	// SubscriptionBackoffMax is the maximum backoff time between event
+	// resubscription attempts.
+	SubscriptionBackoffMax = 2 * time.Minute
+
+	// SubscriptionAlertThreshold is time threshold below which event
+	// resubscription emits an error to the logs.
+	// WS connection can be dropped at any moment and event resubscription will
+	// follow. However, if WS connection for event subscription is getting
+	// dropped too often, it may indicate something is wrong with Ethereum
+	// client. This constant defines the minimum lifetime of an event
+	// subscription required before the subscription failure happens and
+	// resubscription follows so that the resubscription does not emit an error
+	// to the logs alerting about potential problems with Ethereum client
+	// connection.
+	SubscriptionAlertThreshold = 15 * time.Minute
 )
 
 // SubscribeOpts specifies optional configuration options that can be passed

--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -10,6 +10,7 @@ import (
     "github.com/ethereum/go-ethereum/common/hexutil"
     "github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
     "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
     "github.com/keep-network/keep-common/pkg/cmd"
 
@@ -226,6 +227,14 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
 	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
 
+    blockCounter, err := blockcounter.CreateBlockCounter(client)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to create Ethereum blockcounter: [%v]",
+			err,
+		)
+	}
+
     address := common.HexToAddress(config.ContractAddresses["{{.Class}}"])
 
     return contract.New{{.Class}}(
@@ -234,6 +243,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         client,
         ethutil.NewNonceManager(key.Address, client),
         miningWaiter,
+        blockCounter,
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -227,7 +227,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
 	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
 
-    blockCounter, err := blockcounter.CreateBlockCounter(client)
+	blockCounter, err := blockcounter.CreateBlockCounter(client)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create Ethereum blockcounter: [%v]",

--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -10,7 +10,7 @@ import (
     "github.com/ethereum/go-ethereum/common/hexutil"
     "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
+    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
     "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
     "github.com/keep-network/keep-common/pkg/cmd"
 

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -230,7 +230,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
 	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
 
-    blockCounter, err := blockcounter.CreateBlockCounter(client)
+	blockCounter, err := blockcounter.CreateBlockCounter(client)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create Ethereum blockcounter: [%v]",

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -13,7 +13,7 @@ import (
     "github.com/ethereum/go-ethereum/common/hexutil"
     "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
+    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
     "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
     "github.com/keep-network/keep-common/pkg/cmd"
 

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -13,6 +13,7 @@ import (
     "github.com/ethereum/go-ethereum/common/hexutil"
     "github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
     "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
     "github.com/keep-network/keep-common/pkg/cmd"
 
@@ -229,6 +230,14 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
 	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
 
+    blockCounter, err := blockcounter.CreateBlockCounter(client)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to create Ethereum blockcounter: [%v]",
+			err,
+		)
+	}
+
     address := common.HexToAddress(config.ContractAddresses["{{.Class}}"])
 
     return contract.New{{.Class}}(
@@ -237,6 +246,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         client,
         ethutil.NewNonceManager(key.Address, client),
         miningWaiter,
+        blockCounter,
         &sync.Mutex{},
     )
 }

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -26,21 +26,6 @@ import (
 // included or excluded from logging at startup by name.
 var {{.ShortVar}}Logger = log.Logger("keep-contract-{{.Class}}")
 
-const (
-    // Maximum backoff time between event resubscription attempts.
-    {{.ShortVar}}SubscriptionBackoffMax = 2 * time.Minute
-
-    // Threshold below which event resubscription emits an error to the logs.
-    // WS connection can be dropped at any moment and event resubscription will
-    // follow. However, if WS connection for event subscription is getting
-    // dropped too often, it may indicate something is wrong with Ethereum
-    // client. This constant defines the minimum lifetime of an event
-    // subscription required before the subscription failure happens and
-    // resubscription follows so that the resubscription does not emit an error
-    // to the logs alerting about potential problems with Ethereum client.
-    {{.ShortVar}}SubscriptionAlertThreshold = 15 * time.Minute
-)
-
 type {{.Class}} struct {
 	contract           *abi.{{.AbiClass}}
 	contractAddress    common.Address

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ipfs/go-log"
 
+    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/subscription"
 )
@@ -51,6 +52,7 @@ type {{.Class}} struct {
 	errorResolver      *ethutil.ErrorResolver
 	nonceManager       *ethutil.NonceManager
 	miningWaiter       *ethutil.MiningWaiter
+	blockCounter	   *blockcounter.EthereumBlockCounter
 
 	transactionMutex *sync.Mutex
 }
@@ -61,6 +63,7 @@ func New{{.Class}}(
     backend bind.ContractBackend,
     nonceManager *ethutil.NonceManager,
     miningWaiter *ethutil.MiningWaiter,
+	blockCounter *blockcounter.EthereumBlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
@@ -99,6 +102,7 @@ func New{{.Class}}(
 		errorResolver:     ethutil.NewErrorResolver(backend, &contractABI, &contractAddress),
 		nonceManager:      nonceManager,
 		miningWaiter:      miningWaiter,
+		blockCounter: 	   blockCounter,
 		transactionMutex:  transactionMutex,
 	}, nil
 }

--- a/tools/generators/ethereum/contract.go.tmpl
+++ b/tools/generators/ethereum/contract.go.tmpl
@@ -16,7 +16,7 @@ import (
 
 	"github.com/ipfs/go-log"
 
-    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/subscription"
 )
@@ -63,7 +63,7 @@ func New{{.Class}}(
     backend bind.ContractBackend,
     nonceManager *ethutil.NonceManager,
     miningWaiter *ethutil.MiningWaiter,
-	blockCounter *blockcounter.EthereumBlockCounter,
+    blockCounter *blockcounter.EthereumBlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -9,8 +9,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
-	if opts.TickDuration == 0 {
-		opts.TickDuration = ethutil.DefaultSubscribeOptsTickDuration
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
 	}
 	if opts.BlocksBack == 0 {
 		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
@@ -64,7 +64,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -12,8 +12,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	if opts.Tick == 0 {
 		opts.Tick = ethutil.DefaultSubscribeOptsTick
 	}
-	if opts.BlocksBack == 0 {
-		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
 	return &{{$event.SubscriptionCapsName}}{
@@ -78,7 +78,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 						err,
 					)
 				}
-				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
+				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.PastBlocks
 
 				{{$logger}}.Infof(
 					"subscription monitoring fetching past {{$event.CapsName}} events " +

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -5,32 +5,143 @@
 func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	opts *ethutil.SubscribeOpts,
 	{{$event.IndexedFilterDeclarations -}}
-) *{{$event.CapsName}}Subscription {
-	return &{{$event.CapsName}}Subscription{
+) *{{$event.SubscriptionCapsName}} {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.TickDuration == 0 {
+		opts.TickDuration = ethutil.DefaultSubscribeOptsTickDuration
+	}
+	if opts.BlocksBack == 0 {
+		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
+	}
+
+	return &{{$event.SubscriptionCapsName}}{
+		{{$contract.ShortVar}},
 		opts,
 		{{$event.IndexedFilters}}
 	}
 }
 
-type {{$event.CapsName}}Subscription struct {
+type {{$event.SubscriptionCapsName}} struct {
+	contract *{{$contract.Class}}
 	opts *ethutil.SubscribeOpts
 	{{$event.IndexedFilterFields -}}
-}
-
-func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) Pipe(
-	chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
-) {
-
 }
 
 type {{$contract.FullVar}}{{$event.CapsName}}Func func(
 	{{$event.ParamDeclarations -}}
 )
 
-func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) OnEvent(
+func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
-) {
+) subscription.EventSubscription {
+	onEventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
+	ctx, cancel := context.WithCancel(context.Background())
 
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <- onEventChan:
+			    handler(
+					{{$event.ParamExtractors}}
+				)
+			}
+		}
+	}()
+
+	sub := {{$event.SubscriptionShortVar}}.Pipe(onEventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancel()
+	})
+}
+
+func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
+	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+) subscription.EventSubscription {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				lastBlock, err := {{$event.SubscriptionShortVar}}.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					{{$logger}}.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				events, err := {{$event.SubscriptionShortVar}}.contract.Past{{$event.CapsName}}Events(
+					lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack,
+					nil,
+					{{$event.IndexedFilterExtractors}}
+				)
+				if err != nil {
+					{{$logger}}.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := {{$event.SubscriptionShortVar}}.contract.watch{{$event.CapsName}}(
+		sink,
+		{{$event.IndexedFilterExtractors}}
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancel()
+	})
+}
+
+func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
+	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+	{{$event.IndexedFilterDeclarations -}}
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			{{$event.IndexedFilters}}
+		)
+	}
+
+	return ethutil.WithResubscription(
+		{{$contract.ShortVar}}SubscriptionBackoffMax,
+		subscribeFn,
+		{{$contract.ShortVar}}SubscriptionAlertThreshold,
+		func(elapsed time.Duration) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} had to be "+
+						"retried [%v] since the last attempt; please inspect "+
+						"Ethereum client connectivity",
+					elapsed,
+				)
+		},
+		func(err error) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} failed "+
+						"with error: [%v]; resubscription attempt will be "+
+						"performed",
+					err,
+				)
+		},
+	)
 }
 
 func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events(
@@ -60,65 +171,6 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events
 	}
 
 	return events, nil
-}
-
-func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
-	success {{$contract.FullVar}}{{$event.CapsName}}Func,
-	{{$event.IndexedFilterDeclarations -}}
-) (subscription.EventSubscription) {
-	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// TODO: Watch* function will soon accept channel as a parameter instead
-	// of the callback. This loop will be eliminated then.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventOccurred:
-				success(
-                    {{$event.ParamExtractors}}
-				)
-			}
-		}
-	}()
-
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
-			&bind.WatchOpts{Context: ctx},
-			eventOccurred,
-			{{$event.IndexedFilters}}
-		)
-	}
-
-	sub := ethutil.WithResubscription(
-		{{$contract.ShortVar}}SubscriptionBackoffMax,
-		subscribeFn,
-		{{$contract.ShortVar}}SubscriptionAlertThreshold,
-		func(elapsed time.Duration) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} had to be "+
-						"retried [%v] since the last attempt; please inspect "+
-						"Ethereum client connectivity",
-					elapsed,
-				)
-		},
-		func(err error) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} failed "+
-						"with error: [%v]; resubscription attempt will be "+
-						"performed",
-					err,
-				)
-		},
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancel()
-	})
 }
 
 {{- end -}}

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -36,7 +36,7 @@ type {{$contract.FullVar}}{{$event.CapsName}}Func func(
 func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
 ) subscription.EventSubscription {
-	onEventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
+	eventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
@@ -44,7 +44,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 			select {
 			case <-ctx.Done():
 				return
-			case event := <- onEventChan:
+			case event := <- eventChan:
 			    handler(
 					{{$event.ParamExtractors}}
 				)
@@ -52,7 +52,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 		}
 	}()
 
-	sub := {{$event.SubscriptionShortVar}}.Pipe(onEventChan)
+	sub := {{$event.SubscriptionShortVar}}.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancel()

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -65,10 +65,10 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
 		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
-				ticker.Stop()
+			case <-ctx.Done():				
 				return
 			case <-ticker.C:
 				lastBlock, err := {{$event.SubscriptionShortVar}}.contract.blockCounter.CurrentBlock()

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -78,8 +78,15 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 						err,
 					)
 				}
+				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
+
+				{{$logger}}.Debugf(
+					"Subscription monitoring fetching past {{$event.CapsName}} events " +
+					    "starting from block [%v]",
+					fromBlock,
+				)
 				events, err := {{$event.SubscriptionShortVar}}.contract.Past{{$event.CapsName}}Events(
-					lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack,
+					fromBlock,
 					nil,
 					{{$event.IndexedFilterExtractors}}
 				)
@@ -90,6 +97,10 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					)
 					continue
 				}
+				{{$logger}}.Debugf(
+					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
+					len(events),
+				)
 
 				for _, event := range events {
 					sink <- event

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -150,10 +150,10 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
 		)
 	}
 
-	sub := ethutil.WithResubscription(
-		{{$contract.ShortVar}}SubscriptionBackoffMax,
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
 		subscribeFn,
-		{{$contract.ShortVar}}SubscriptionAlertThreshold,
+		ethutil.SubscriptionAlertThreshold,
 		thresholdViolatedFn,
 		subscriptionFailedFn,
 	)

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -81,7 +81,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
 
 				{{$logger}}.Infof(
-					"Subscription monitoring fetching past {{$event.CapsName}} events " +
+					"subscription monitoring fetching past {{$event.CapsName}} events " +
 					    "starting from block [%v]",
 					fromBlock,
 				)
@@ -98,7 +98,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					continue
 				}
 				{{$logger}}.Infof(
-					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
+					"subscription monitoring fetched [%v] past {{$event.CapsName}} events",
 					len(events),
 				)
 

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -80,7 +80,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 				}
 				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
 
-				{{$logger}}.Debugf(
+				{{$logger}}.Infof(
 					"Subscription monitoring fetching past {{$event.CapsName}} events " +
 					    "starting from block [%v]",
 					fromBlock,
@@ -97,7 +97,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					)
 					continue
 				}
-				{{$logger}}.Debugf(
+				{{$logger}}.Infof(
 					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
 					len(events),
 				)

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -37,7 +37,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
 ) subscription.EventSubscription {
 	eventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
 		for {
@@ -55,14 +55,14 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	sub := {{$event.SubscriptionShortVar}}.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 
 func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
 ) subscription.EventSubscription {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
 		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
 		for {
@@ -116,7 +116,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 

--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -2,9 +2,36 @@
 {{- $logger := (print $contract.ShortVar "Logger") -}}
 {{- range $i, $event := .Events }}
 
+func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
+	opts *ethutil.SubscribeOpts,
+	{{$event.IndexedFilterDeclarations -}}
+) *{{$event.CapsName}}Subscription {
+	return &{{$event.CapsName}}Subscription{
+		opts,
+		{{$event.IndexedFilters}}
+	}
+}
+
+type {{$event.CapsName}}Subscription struct {
+	opts *ethutil.SubscribeOpts
+	{{$event.IndexedFilterFields -}}
+}
+
+func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) Pipe(
+	chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+) {
+
+}
+
 type {{$contract.FullVar}}{{$event.CapsName}}Func func(
-    {{$event.ParamDeclarations -}}
+	{{$event.ParamDeclarations -}}
 )
+
+func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) OnEvent(
+	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
+) {
+
+}
 
 func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events(
 	startBlock uint64,

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -15,8 +15,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	if opts.Tick == 0 {
 		opts.Tick = ethutil.DefaultSubscribeOptsTick
 	}
-	if opts.BlocksBack == 0 {
-		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
 	return &{{$event.SubscriptionCapsName}}{
@@ -81,7 +81,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 						err,
 					)
 				}
-				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
+				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.PastBlocks
 
 				{{$logger}}.Infof(
 					"subscription monitoring fetching past {{$event.CapsName}} events " +

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -12,8 +12,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
-	if opts.TickDuration == 0 {
-		opts.TickDuration = ethutil.DefaultSubscribeOptsTickDuration
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
 	}
 	if opts.BlocksBack == 0 {
 		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
@@ -67,7 +67,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -83,7 +83,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 				}
 				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
 
-				{{$logger}}.Debugf(
+				{{$logger}}.Infof(
 					"Subscription monitoring fetching past {{$event.CapsName}} events " +
 					    "starting from block [%v]",
 					fromBlock,
@@ -100,7 +100,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					)
 					continue
 				}
-				{{$logger}}.Debugf(
+				{{$logger}}.Infof(
 					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
 					len(events),
 				)

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -81,8 +81,15 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 						err,
 					)
 				}
+				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
+
+				{{$logger}}.Debugf(
+					"Subscription monitoring fetching past {{$event.CapsName}} events " +
+					    "starting from block [%v]",
+					fromBlock,
+				)
 				events, err := {{$event.SubscriptionShortVar}}.contract.Past{{$event.CapsName}}Events(
-					lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack,
+					fromBlock,
 					nil,
 					{{$event.IndexedFilterExtractors}}
 				)
@@ -93,6 +100,10 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					)
 					continue
 				}
+				{{$logger}}.Debugf(
+					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
+					len(events),
+				)
 
 				for _, event := range events {
 					sink <- event

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -68,10 +68,10 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
 		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
-				ticker.Stop()
+			case <-ctx.Done():				
 				return
 			case <-ticker.C:
 				lastBlock, err := {{$event.SubscriptionShortVar}}.contract.blockCounter.CurrentBlock()

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -40,7 +40,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
 ) subscription.EventSubscription {
 	eventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
 		for {
@@ -58,14 +58,14 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	sub := {{$event.SubscriptionShortVar}}.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 
 func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
 ) subscription.EventSubscription {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
 		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
 		for {
@@ -119,7 +119,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
-		cancel()
+		cancelCtx()
 	})
 }
 

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -84,7 +84,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 				fromBlock := lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack
 
 				{{$logger}}.Infof(
-					"Subscription monitoring fetching past {{$event.CapsName}} events " +
+					"subscription monitoring fetching past {{$event.CapsName}} events " +
 					    "starting from block [%v]",
 					fromBlock,
 				)
@@ -101,7 +101,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
 					continue
 				}
 				{{$logger}}.Infof(
-					"Subscription monitoring fetched [%v] past {{$event.CapsName}} events",
+					"subscription monitoring fetched [%v] past {{$event.CapsName}} events",
 					len(events),
 				)
 

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -5,9 +5,36 @@ var contractEventsTemplateContent = `{{- $contract := . -}}
 {{- $logger := (print $contract.ShortVar "Logger") -}}
 {{- range $i, $event := .Events }}
 
+func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
+	opts *ethutil.SubscribeOpts,
+	{{$event.IndexedFilterDeclarations -}}
+) *{{$event.CapsName}}Subscription {
+	return &{{$event.CapsName}}Subscription{
+		opts,
+		{{$event.IndexedFilters}}
+	}
+}
+
+type {{$event.CapsName}}Subscription struct {
+	opts *ethutil.SubscribeOpts
+	{{$event.IndexedFilterFields -}}
+}
+
+func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) Pipe(
+	chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+) {
+
+}
+
 type {{$contract.FullVar}}{{$event.CapsName}}Func func(
-    {{$event.ParamDeclarations -}}
+	{{$event.ParamDeclarations -}}
 )
+
+func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) OnEvent(
+	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
+) {
+
+}
 
 func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events(
 	startBlock uint64,

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -8,32 +8,143 @@ var contractEventsTemplateContent = `{{- $contract := . -}}
 func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$event.CapsName}}(
 	opts *ethutil.SubscribeOpts,
 	{{$event.IndexedFilterDeclarations -}}
-) *{{$event.CapsName}}Subscription {
-	return &{{$event.CapsName}}Subscription{
+) *{{$event.SubscriptionCapsName}} {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.TickDuration == 0 {
+		opts.TickDuration = ethutil.DefaultSubscribeOptsTickDuration
+	}
+	if opts.BlocksBack == 0 {
+		opts.BlocksBack = ethutil.DefaultSubscribeOptsBlocksBack
+	}
+
+	return &{{$event.SubscriptionCapsName}}{
+		{{$contract.ShortVar}},
 		opts,
 		{{$event.IndexedFilters}}
 	}
 }
 
-type {{$event.CapsName}}Subscription struct {
+type {{$event.SubscriptionCapsName}} struct {
+	contract *{{$contract.Class}}
 	opts *ethutil.SubscribeOpts
 	{{$event.IndexedFilterFields -}}
-}
-
-func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) Pipe(
-	chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
-) {
-
 }
 
 type {{$contract.FullVar}}{{$event.CapsName}}Func func(
 	{{$event.ParamDeclarations -}}
 )
 
-func ({{$event.ShortVar}}s *{{$event.CapsName}}Subscription) OnEvent(
+func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
-) {
+) subscription.EventSubscription {
+	onEventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
+	ctx, cancel := context.WithCancel(context.Background())
 
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <- onEventChan:
+			    handler(
+					{{$event.ParamExtractors}}
+				)
+			}
+		}
+	}()
+
+	sub := {{$event.SubscriptionShortVar}}.Pipe(onEventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancel()
+	})
+}
+
+func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) Pipe(
+	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+) subscription.EventSubscription {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker({{$event.SubscriptionShortVar}}.opts.TickDuration)
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				lastBlock, err := {{$event.SubscriptionShortVar}}.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					{{$logger}}.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				events, err := {{$event.SubscriptionShortVar}}.contract.Past{{$event.CapsName}}Events(
+					lastBlock-{{$event.SubscriptionShortVar}}.opts.BlocksBack,
+					nil,
+					{{$event.IndexedFilterExtractors}}
+				)
+				if err != nil {
+					{{$logger}}.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := {{$event.SubscriptionShortVar}}.contract.watch{{$event.CapsName}}(
+		sink,
+		{{$event.IndexedFilterExtractors}}
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancel()
+	})
+}
+
+func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
+	sink chan *abi.{{$contract.AbiClass}}{{$event.CapsName}},
+	{{$event.IndexedFilterDeclarations -}}
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			{{$event.IndexedFilters}}
+		)
+	}
+
+	return ethutil.WithResubscription(
+		{{$contract.ShortVar}}SubscriptionBackoffMax,
+		subscribeFn,
+		{{$contract.ShortVar}}SubscriptionAlertThreshold,
+		func(elapsed time.Duration) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} had to be "+
+						"retried [%v] since the last attempt; please inspect "+
+						"Ethereum client connectivity",
+					elapsed,
+				)
+		},
+		func(err error) {
+			{{$logger}}.Errorf(
+					"subscription to event {{$event.CapsName}} failed "+
+						"with error: [%v]; resubscription attempt will be "+
+						"performed",
+					err,
+				)
+		},
+	)
 }
 
 func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events(
@@ -63,65 +174,6 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) Past{{$event.CapsName}}Events
 	}
 
 	return events, nil
-}
-
-func ({{$contract.ShortVar}} *{{$contract.Class}}) Watch{{$event.CapsName}}(
-	success {{$contract.FullVar}}{{$event.CapsName}}Func,
-	{{$event.IndexedFilterDeclarations -}}
-) (subscription.EventSubscription) {
-	eventOccurred := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// TODO: Watch* function will soon accept channel as a parameter instead
-	// of the callback. This loop will be eliminated then.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventOccurred:
-				success(
-                    {{$event.ParamExtractors}}
-				)
-			}
-		}
-	}()
-
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return {{$contract.ShortVar}}.contract.Watch{{$event.CapsName}}(
-			&bind.WatchOpts{Context: ctx},
-			eventOccurred,
-			{{$event.IndexedFilters}}
-		)
-	}
-
-	sub := ethutil.WithResubscription(
-		{{$contract.ShortVar}}SubscriptionBackoffMax,
-		subscribeFn,
-		{{$contract.ShortVar}}SubscriptionAlertThreshold,
-		func(elapsed time.Duration) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} had to be "+
-						"retried [%v] since the last attempt; please inspect "+
-						"Ethereum client connectivity",
-					elapsed,
-				)
-		},
-		func(err error) {
-			{{$logger}}.Errorf(
-					"subscription to event {{$event.CapsName}} failed "+
-						"with error: [%v]; resubscription attempt will be "+
-						"performed",
-					err,
-				)
-		},
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancel()
-	})
 }
 
 {{- end -}}`

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -153,10 +153,10 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
 		)
 	}
 
-	sub := ethutil.WithResubscription(
-		{{$contract.ShortVar}}SubscriptionBackoffMax,
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
 		subscribeFn,
-		{{$contract.ShortVar}}SubscriptionAlertThreshold,
+		ethutil.SubscriptionAlertThreshold,
 		thresholdViolatedFn,
 		subscriptionFailedFn,
 	)

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -39,7 +39,7 @@ type {{$contract.FullVar}}{{$event.CapsName}}Func func(
 func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 	handler {{$contract.FullVar}}{{$event.CapsName}}Func,
 ) subscription.EventSubscription {
-	onEventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
+	eventChan := make(chan *abi.{{$contract.AbiClass}}{{$event.CapsName}})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
@@ -47,7 +47,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 			select {
 			case <-ctx.Done():
 				return
-			case event := <- onEventChan:
+			case event := <- eventChan:
 			    handler(
 					{{$event.ParamExtractors}}
 				)
@@ -55,7 +55,7 @@ func ({{$event.SubscriptionShortVar}} *{{$event.SubscriptionCapsName}}) OnEvent(
 		}
 	}()
 
-	sub := {{$event.SubscriptionShortVar}}.Pipe(onEventChan)
+	sub := {{$event.SubscriptionShortVar}}.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancel()

--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -80,10 +80,12 @@ type returnInfo struct {
 type eventInfo struct {
 	CapsName                  string
 	LowerName                 string
+	ShortVar                  string
 	IndexedFilters            string
 	ParamExtractors           string
 	ParamDeclarations         string
 	IndexedFilterDeclarations string
+	IndexedFilterFields       string
 }
 
 func buildContractInfo(
@@ -245,6 +247,7 @@ func buildEventInfo(eventsByName map[string]abi.Event) []eventInfo {
 		paramDeclarations := ""
 		paramExtractors := ""
 		indexedFilterDeclarations := ""
+		indexedFilterFields := ""
 		indexedFilters := ""
 		for _, param := range event.Inputs {
 			upperParam := uppercaseFirst(param.Name)
@@ -254,6 +257,7 @@ func buildEventInfo(eventsByName map[string]abi.Event) []eventInfo {
 			paramExtractors += fmt.Sprintf("event.%v,\n", upperParam)
 			if param.Indexed {
 				indexedFilterDeclarations += fmt.Sprintf("%vFilter []%v,\n", param.Name, goType)
+				indexedFilterFields += fmt.Sprintf("%vFilter []%v\n", param.Name, goType)
 				indexedFilters += fmt.Sprintf("%vFilter,\n", param.Name)
 			}
 		}
@@ -261,13 +265,20 @@ func buildEventInfo(eventsByName map[string]abi.Event) []eventInfo {
 		paramDeclarations += "blockNumber uint64,\n"
 		paramExtractors += "event.Raw.BlockNumber,\n"
 
+		shortVar := strings.ToLower(string(shortVarRegexp.ReplaceAll(
+			[]byte(name),
+			[]byte("$1"),
+		)))
+
 		eventInfos = append(eventInfos, eventInfo{
 			uppercaseFirst(name),
 			lowercaseFirst(name),
+			shortVar,
 			indexedFilters,
 			paramExtractors,
 			paramDeclarations,
 			indexedFilterDeclarations,
+			indexedFilterFields,
 		})
 	}
 

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ipfs/go-log"
 
+    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/subscription"
 )
@@ -54,6 +55,7 @@ type {{.Class}} struct {
 	errorResolver      *ethutil.ErrorResolver
 	nonceManager       *ethutil.NonceManager
 	miningWaiter       *ethutil.MiningWaiter
+	blockCounter	   *blockcounter.EthereumBlockCounter
 
 	transactionMutex *sync.Mutex
 }
@@ -64,6 +66,7 @@ func New{{.Class}}(
     backend bind.ContractBackend,
     nonceManager *ethutil.NonceManager,
     miningWaiter *ethutil.MiningWaiter,
+	blockCounter *blockcounter.EthereumBlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{
@@ -102,6 +105,7 @@ func New{{.Class}}(
 		errorResolver:     ethutil.NewErrorResolver(backend, &contractABI, &contractAddress),
 		nonceManager:      nonceManager,
 		miningWaiter:      miningWaiter,
+		blockCounter: 	   blockCounter,
 		transactionMutex:  transactionMutex,
 	}, nil
 }

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -29,21 +29,6 @@ import (
 // included or excluded from logging at startup by name.
 var {{.ShortVar}}Logger = log.Logger("keep-contract-{{.Class}}")
 
-const (
-    // Maximum backoff time between event resubscription attempts.
-    {{.ShortVar}}SubscriptionBackoffMax = 2 * time.Minute
-
-    // Threshold below which event resubscription emits an error to the logs.
-    // WS connection can be dropped at any moment and event resubscription will
-    // follow. However, if WS connection for event subscription is getting
-    // dropped too often, it may indicate something is wrong with Ethereum
-    // client. This constant defines the minimum lifetime of an event
-    // subscription required before the subscription failure happens and
-    // resubscription follows so that the resubscription does not emit an error
-    // to the logs alerting about potential problems with Ethereum client.
-    {{.ShortVar}}SubscriptionAlertThreshold = 15 * time.Minute
-)
-
 type {{.Class}} struct {
 	contract           *abi.{{.AbiClass}}
 	contractAddress    common.Address

--- a/tools/generators/ethereum/contract_template_content.go
+++ b/tools/generators/ethereum/contract_template_content.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/ipfs/go-log"
 
-    "github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/subscription"
 )
@@ -66,7 +66,7 @@ func New{{.Class}}(
     backend bind.ContractBackend,
     nonceManager *ethutil.NonceManager,
     miningWaiter *ethutil.MiningWaiter,
-	blockCounter *blockcounter.EthereumBlockCounter,
+    blockCounter *blockcounter.EthereumBlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {
 	callerOptions := &bind.CallOpts{


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-ecdsa/issues/680

Depends on keep-network/keep-common#62

See https://github.com/keep-network/keep-ecdsa/pull/671

# Overview 

There are two major changes to Ethereum subscription API proposed here:
- new subscription API with `OnEvent` and `Pipe` functions,
- background monitoring loop pulling past events from the chain.

The first change should allow implementing some handler logic easier and to avoid complex logic leading to bugs such as https://github.com/keep-network/keep-core/issues/1333 or https://github.com/keep-network/keep-core/issues/2052.

The second change should improve client responsiveness for operators running their nodes against Ethereum deployments that are not very reliable on the event delivery front.
  
This code has been integrated with ECDSA keep client in `keep-ecdsa` repository and can be tested there on the branch `pipe-it` (https://github.com/keep-network/keep-ecdsa/pull/671).

# New API

Event subscription API has been refactored to resemble the proposition from https://github.com/keep-network/keep-core/issues/491. The new event subscription mechanism allows installing event callback handler function with `OnEvent` function as well as piping events from a subscription to a channel with `Pipe` function.

Example usage of `OnEvent`:
```
handlerFn := func(
    submittingMember common.Address,
    conflictingPublicKey []byte,
    blockNumber uint64,
) {
   // (...)
}
subscription := keepContract.ConflictingPublicKeySubmitted(
	nil, // default SubscribeOpts
	nil, // no filtering on submitting member
).OnEvent(handlerFn)
```

The same subscription but with a `Pipe`:
```
sink := make(chan *abi.BondedECDSAKeepConflictingPublicKeySubmitted)

subscription := keepContract.ConflictingPublicKeySubmitted(
	nil, // default SubscribeOpts
	nil, // no filtering on submitting member
).Pipe(sink)
```

Currently, all our event subscriptions use function handlers. While it is convenient in some cases, in some other cases it is the opposite. For example, `OnBondedECDSAKeepCreated` handler in ECDSA client works perfectly fine as a function. It triggers the protocol and does not have to constantly monitor the state of the chain. On the other hand, `OnDKGResultSubmitted` handler from the beacon client needs to monitor the chain and exit the process of event publication in case another node has published the result. In this case, the code could be better structured with a channel-based subscription that would allow listening for block counter events and events from DKG result submitted subscription in one for-select loop.

# Background monitoring loop

Some nodes in the network are running against Ethereum setups that are not particularly reliable in delivering events. Events are not delivered, nodes are not starting key-generation, or are not participating in redemption signing. Another problem is the stability of the event subscription mechanism (see https://github.com/keep-network/keep-common/pull/62). If the web socket connection is dropped too often, the resubscription mechanism is not enough to receive events emitted when the connection was in a weird, stale state.

To address this problem, we introduce a background loop periodically pulling past events from the chain next to a regular `watchLogs` subscription. How often events are pulled and how many blocks are taken into account can be configured with `SubscribeOpts` parameters. 

This way, even if the event was lost by `watchLogs` subscription for whatever reason, it should be pulled by a background monitoring loop later. An extremely important implication of this change is that handlers should have a logic in place allowing them to de-duplicate received events even if a lot of time passed between receiving the original event and the duplicate.

I have been experimenting with various options here, including de-duplication events in the chain implementation layer, but none of them proved to be successful as the correct de-duplication algorithm requires domain knowledge about a certain type of an event and in what circumstances identical event emitted later should or should not be identified as a duplicate.

De-duplicator implementations should be added to `keep-core` and `keep-ecdsa` clients and are out of the scope of `keep-common` and this PR.