### PR TITLE
Refactor `ContractAddress` method in config structs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ replace github.com/urfave/cli => github.com/keep-network/cli v1.20.0
 require (
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20190924011532-60b7b74727fd // indirect
-	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/celo-org/celo-blockchain v0.0.0-20210222234634-f8c8f6744526
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VictoriaMetrics/fastcache v1.5.3 h1:2odJnXLbFZcoV9KYtQ+7TH1UOq3dn3AssMgieaezkR4=
 github.com/VictoriaMetrics/fastcache v1.5.3/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
+github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -52,9 +53,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
-github.com/celo-org/celo-blockchain v0.0.0-20210211195335-cbc4f555cf87 h1:JQMKfHxfbjc8EgyUgvQ1nNkZcipFp/YgK0WVYHFQFTo=
-github.com/celo-org/celo-blockchain v0.0.0-20210211195335-cbc4f555cf87/go.mod h1:HIiEH2YuxBp8+kr/+Ltmk4h6Ml3HdmgNYvJvFs6FeyQ=
 github.com/celo-org/celo-blockchain v0.0.0-20210222234634-f8c8f6744526 h1:rdY1F8vUybjjsv+V58eaSYsYPTNO+AXK9o7l+BQuhhU=
 github.com/celo-org/celo-blockchain v0.0.0-20210222234634-f8c8f6744526/go.mod h1:4tbv23s4i0AU7+KN5UP2RaB5c9OMXedtx9F7wJ+s0Jo=
 github.com/celo-org/celo-bls-go v0.2.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
@@ -187,6 +187,7 @@ github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HN
 github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
@@ -295,6 +296,7 @@ golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaE
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -346,6 +348,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -357,6 +360,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190912185636-87d9f09c5d89 h1:WiVZGyzQN7gPNLRkkpsNX3jC0Jx5j9GxadCZW/8eXw0=
 golang.org/x/tools v0.0.0-20190912185636-87d9f09c5d89/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69 h1:yBHHx+XZqXJBm6Exke3N7V9gnlsyXxoCPEb1yVenjfk=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -379,6 +383,7 @@ gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLv
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20190213234257-ec84240a7772/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
+gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200316214253-d7b0ff38cac9 h1:ITeyKbRetrVzqR3U1eY+ywgp7IBspGd1U/bkwd1gWu4=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200316214253-d7b0ff38cac9/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/redis.v4 v4.2.4/go.mod h1:8KREHdypkCEojGKQcjMqAODMICIVwZAONWq8RowTITA=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=

--- a/pkg/chain/celo/config.go
+++ b/pkg/chain/celo/config.go
@@ -25,17 +25,17 @@ type Config struct {
 
 // ContractAddress finds a given contract's address configuration and returns it
 // as Celo address.
-func (c *Config) ContractAddress(contractName string) (*common.Address, error) {
+func (c *Config) ContractAddress(contractName string) (common.Address, error) {
 	addressString, exists := c.ContractAddresses[contractName]
 	if !exists {
-		return nil, fmt.Errorf(
+		return common.Address{}, fmt.Errorf(
 			"no address information for [%v] in configuration",
 			contractName,
 		)
 	}
 
 	if !common.IsHexAddress(addressString) {
-		return nil, fmt.Errorf(
+		return common.Address{}, fmt.Errorf(
 			"configured address [%v] for contract [%v] "+
 				"is not valid hex address",
 			addressString,
@@ -44,5 +44,5 @@ func (c *Config) ContractAddress(contractName string) (*common.Address, error) {
 	}
 
 	address := common.HexToAddress(addressString)
-	return &address, nil
+	return address, nil
 }

--- a/pkg/chain/celo/config_test.go
+++ b/pkg/chain/celo/config_test.go
@@ -28,16 +28,16 @@ func TestContractAddress(t *testing.T) {
 
 	var tests = map[string]struct {
 		contractName    string
-		expectedAddress *common.Address
+		expectedAddress common.Address
 		expectedError   error
 	}{
 		"contract name matching valid configuration": {
 			contractName:    contractName1,
-			expectedAddress: &validContractAddress,
+			expectedAddress: validContractAddress,
 		},
 		"invalid contract hex address": {
 			contractName:    contractName2,
-			expectedAddress: nil,
+			expectedAddress: common.Address{},
 			expectedError: fmt.Errorf(
 				"configured address [%v] for contract [%v] "+
 					"is not valid hex address",
@@ -47,7 +47,7 @@ func TestContractAddress(t *testing.T) {
 		},
 		"missing contract configuration": {
 			contractName:    "Peekaboo",
-			expectedAddress: nil,
+			expectedAddress: common.Address{},
 			expectedError: fmt.Errorf("no address information " +
 				"for [Peekaboo] in configuration"),
 		},

--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -25,17 +25,17 @@ type Config struct {
 
 // ContractAddress finds a given contract's address configuration and returns it
 // as Ethereum address.
-func (c *Config) ContractAddress(contractName string) (*common.Address, error) {
+func (c *Config) ContractAddress(contractName string) (common.Address, error) {
 	addressString, exists := c.ContractAddresses[contractName]
 	if !exists {
-		return nil, fmt.Errorf(
+		return common.Address{}, fmt.Errorf(
 			"no address information for [%v] in configuration",
 			contractName,
 		)
 	}
 
 	if !common.IsHexAddress(addressString) {
-		return nil, fmt.Errorf(
+		return common.Address{}, fmt.Errorf(
 			"configured address [%v] for contract [%v] "+
 				"is not valid hex address",
 			addressString,
@@ -44,5 +44,5 @@ func (c *Config) ContractAddress(contractName string) (*common.Address, error) {
 	}
 
 	address := common.HexToAddress(addressString)
-	return &address, nil
+	return address, nil
 }

--- a/pkg/chain/ethereum/config_test.go
+++ b/pkg/chain/ethereum/config_test.go
@@ -28,16 +28,16 @@ func TestContractAddress(t *testing.T) {
 
 	var tests = map[string]struct {
 		contractName    string
-		expectedAddress *common.Address
+		expectedAddress common.Address
 		expectedError   error
 	}{
 		"contract name matching valid configuration": {
 			contractName:    contractName1,
-			expectedAddress: &validContractAddress,
+			expectedAddress: validContractAddress,
 		},
 		"invalid contract hex address": {
 			contractName:    contractName2,
-			expectedAddress: nil,
+			expectedAddress: common.Address{},
 			expectedError: fmt.Errorf(
 				"configured address [%v] for contract [%v] "+
 					"is not valid hex address",
@@ -47,7 +47,7 @@ func TestContractAddress(t *testing.T) {
 		},
 		"missing contract configuration": {
 			contractName:    "Peekaboo",
-			expectedAddress: nil,
+			expectedAddress: common.Address{},
 			expectedError: fmt.Errorf("no address information " +
 				"for [Peekaboo] in configuration"),
 		},


### PR DESCRIPTION
`ContractAddress` method in both Ethereum's and Celo's config structs should return a plain `common.Address` type instead of a pointer. This should eliminate the need for nil-checks in the client code.