### PR TITLE
Backport: Adjust Ethereum contracts to use EIP155 signer

### DIFF
--- a/tools/generators/ethlike/command.go.tmpl
+++ b/tools/generators/ethlike/command.go.tmpl
@@ -203,6 +203,14 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         return nil, fmt.Errorf("error connecting to host chain node: [%v]", err)
     }
 
+   	chainID, err := client.ChainID(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to resolve host chain id: [%v]",
+			err,
+		)
+	}
+
     key, err := chainutil.DecryptKeyFile(
         config.Account.KeyFile,
         config.Account.KeyFilePassword,
@@ -242,6 +250,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
     return contract.New{{.Class}}(
         address,
+        chainID,
         key,
         client,
         chainutil.NewNonceManager(client, key.Address),

--- a/tools/generators/ethlike/command_template_content.go
+++ b/tools/generators/ethlike/command_template_content.go
@@ -206,6 +206,14 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         return nil, fmt.Errorf("error connecting to host chain node: [%v]", err)
     }
 
+   	chainID, err := client.ChainID(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to resolve host chain id: [%v]",
+			err,
+		)
+	}
+
     key, err := chainutil.DecryptKeyFile(
         config.Account.KeyFile,
         config.Account.KeyFilePassword,
@@ -245,6 +253,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
 
     return contract.New{{.Class}}(
         address,
+        chainID,
         key,
         client,
         chainutil.NewNonceManager(client, key.Address),

--- a/tools/generators/ethlike/contract.go.tmpl
+++ b/tools/generators/ethlike/contract.go.tmpl
@@ -61,6 +61,9 @@ func New{{.Class}}(
 	// FIXME bumps beyond 1.9.25.
 	key := accountKey.PrivateKey
 	keyAddress := crypto.PubkeyToAddress(key.PublicKey)
+	if chainId == nil {
+		return nil, fmt.Errorf("no chain id specified")
+	}
 	transactorOptions := &bind.TransactOpts{
 		From: keyAddress,
 		Signer: func(_ types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {

--- a/tools/generators/ethlike/contract.go.tmpl
+++ b/tools/generators/ethlike/contract.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"{{.HostChainModule}}/accounts/keystore"
 	"{{.HostChainModule}}/common"
 	"{{.HostChainModule}}/core/types"
+	"{{.HostChainModule}}/crypto"
 	"{{.HostChainModule}}/event"
 
 	"github.com/ipfs/go-log"
@@ -44,6 +45,7 @@ type {{.Class}} struct {
 
 func New{{.Class}}(
     contractAddress common.Address,
+    chainId *big.Int,
     accountKey *keystore.Key,
     backend bind.ContractBackend,
     nonceManager *ethlike.NonceManager,
@@ -55,9 +57,25 @@ func New{{.Class}}(
 		From: accountKey.Address,
 	}
 
-	transactorOptions := bind.NewKeyedTransactor(
-		accountKey.PrivateKey,
-	)
+	// FIXME Switch to bind.NewKeyedTransactorWithChainID when go-ethereum dep
+	// FIXME bumps beyond 1.9.25.
+	key := accountKey.PrivateKey
+	keyAddress := crypto.PubkeyToAddress(key.PublicKey)
+	transactorOptions := &bind.TransactOpts{
+		From: keyAddress,
+		Signer: func(_ types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			signer := types.NewEIP155Signer(chainId)
+
+			if address != keyAddress {
+				return nil, fmt.Errorf("not authorized to sign this account")
+			}
+			signature, err := crypto.Sign(signer.Hash(tx).Bytes(), key)
+			if err != nil {
+				return nil, err
+			}
+			return tx.WithSignature(signer, signature)
+		},
+	}
 
 	contract, err := abi.New{{.AbiClass}}(
 		contractAddress,

--- a/tools/generators/ethlike/contract_template_content.go
+++ b/tools/generators/ethlike/contract_template_content.go
@@ -64,6 +64,9 @@ func New{{.Class}}(
 	// FIXME bumps beyond 1.9.25.
 	key := accountKey.PrivateKey
 	keyAddress := crypto.PubkeyToAddress(key.PublicKey)
+	if chainId == nil {
+		return nil, fmt.Errorf("no chain id specified")
+	}
 	transactorOptions := &bind.TransactOpts{
 		From: keyAddress,
 		Signer: func(_ types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {


### PR DESCRIPTION
go-ethereum 1.10.0 has switched to denying non-EIP155 signatures by default.
Although our code uses go-ethereum's own ABI binding generation, the version
currently in our dependencies never added support for EIP155 signers, and
instead always uses Homestead signers for the transactors it provides helpers
for.

In the short term, this commit manually creates the transactor options for the
account key, forcing an EIP155 signer when doing signing. When the go-ethereum
dependency gets bumped past 1.9.25, we will be able to move back to
`NewKeyedTransactorWithChainID`, which uses an EIP155 signer under the hood.