### PR TITLE
Add Go linting to the client.yml workflow

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -39,3 +39,11 @@ jobs:
       - uses: securego/gosec@master
         with:
           args: ./...
+
+  client-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint Go
+        uses: keep-network/golint-action@v1.0.2

--- a/pkg/chain/ethlike/block_counter.go
+++ b/pkg/chain/ethlike/block_counter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// BlockCounter represents a block counter
 type BlockCounter struct {
 	structMutex         sync.Mutex
 	latestBlockHeight   uint64
@@ -25,6 +26,7 @@ type watcher struct {
 	channel chan uint64
 }
 
+// WaitForBlockHeight waits for a given block height
 func (bc *BlockCounter) WaitForBlockHeight(blockNumber uint64) error {
 	waiter, err := bc.BlockHeightWaiter(blockNumber)
 	if err != nil {
@@ -34,6 +36,7 @@ func (bc *BlockCounter) WaitForBlockHeight(blockNumber uint64) error {
 	return nil
 }
 
+// BlockHeightWaiter returns a waiter for the given block
 func (bc *BlockCounter) BlockHeightWaiter(
 	blockNumber uint64,
 ) (<-chan uint64, error) {
@@ -56,10 +59,12 @@ func (bc *BlockCounter) BlockHeightWaiter(
 	return newWaiter, nil
 }
 
+// CurrentBlock returns the current block
 func (bc *BlockCounter) CurrentBlock() (uint64, error) {
 	return bc.latestBlockHeight, nil
 }
 
+// WatchBlocks watches the blocks
 func (bc *BlockCounter) WatchBlocks(ctx context.Context) <-chan uint64 {
 	watcher := &watcher{
 		ctx:     ctx,
@@ -206,6 +211,7 @@ func (bc *BlockCounter) subscribeBlocks(
 	return nil
 }
 
+// CreateBlockCounter creates a block counter
 func CreateBlockCounter(chainReader ChainReader) (*BlockCounter, error) {
 	ctx := context.Background()
 

--- a/pkg/chain/ethlike/block_counter.go
+++ b/pkg/chain/ethlike/block_counter.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// BlockCounter represents a block counter
+// BlockCounter represents a block counter.
 type BlockCounter struct {
 	structMutex         sync.Mutex
 	latestBlockHeight   uint64
@@ -26,7 +26,7 @@ type watcher struct {
 	channel chan uint64
 }
 
-// WaitForBlockHeight waits for a given block height
+// WaitForBlockHeight waits for a given block height.
 func (bc *BlockCounter) WaitForBlockHeight(blockNumber uint64) error {
 	waiter, err := bc.BlockHeightWaiter(blockNumber)
 	if err != nil {
@@ -36,7 +36,7 @@ func (bc *BlockCounter) WaitForBlockHeight(blockNumber uint64) error {
 	return nil
 }
 
-// BlockHeightWaiter returns a waiter for the given block
+// BlockHeightWaiter returns a waiter for the given block.
 func (bc *BlockCounter) BlockHeightWaiter(
 	blockNumber uint64,
 ) (<-chan uint64, error) {
@@ -59,12 +59,12 @@ func (bc *BlockCounter) BlockHeightWaiter(
 	return newWaiter, nil
 }
 
-// CurrentBlock returns the current block
+// CurrentBlock returns the current block.
 func (bc *BlockCounter) CurrentBlock() (uint64, error) {
 	return bc.latestBlockHeight, nil
 }
 
-// WatchBlocks watches the blocks
+// WatchBlocks watches the blocks.
 func (bc *BlockCounter) WatchBlocks(ctx context.Context) <-chan uint64 {
 	watcher := &watcher{
 		ctx:     ctx,
@@ -211,7 +211,7 @@ func (bc *BlockCounter) subscribeBlocks(
 	return nil
 }
 
-// CreateBlockCounter creates a block counter
+// CreateBlockCounter creates a block counter.
 func CreateBlockCounter(chainReader ChainReader) (*BlockCounter, error) {
 	ctx := context.Background()
 

--- a/pkg/chain/ethlike/token.go
+++ b/pkg/chain/ethlike/token.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 )
 
+// Token represents a token
 type Token struct {
 	*big.Int
 }
 
-// UnmarshalText is a function used to parse an ETH-like token.
+// UnmarshalToken is a function used to parse an ETH-like token.
 func (t *Token) UnmarshalToken(text []byte, units map[string]float64) error {
 	re := regexp.MustCompile(`^(\d+[\.]?[\d]*)[ ]?([\w]*)$`)
 	matched := re.FindSubmatch(text)

--- a/pkg/chain/ethlike/token.go
+++ b/pkg/chain/ethlike/token.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Token represents a token
+// Token represents a token.
 type Token struct {
 	*big.Int
 }

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,4 +1,4 @@
-// Package `diagnostics` provides some tools useful for gathering and
+// Package diagnostics provides some tools useful for gathering and
 // exposing arbitrary diagnositcs information for external monitoring tools.
 //
 // Possible usage: integration nodes list into dashboard
@@ -18,21 +18,21 @@ var logger = log.Logger("keep-diagnostics")
 
 // Registry performs all management of diagnostic. Specifically, it allows
 // to registering new diagnostics sources and exposing them through the diagnostics server.
-type DiagnosticsRegistry struct {
+type Registry struct {
 	diagnosticsSources map[string]func() string
 	diagnosticsMutex   sync.RWMutex
 }
 
 // NewRegistry creates a new metrics registry.
-func NewRegistry() *DiagnosticsRegistry {
-	return &DiagnosticsRegistry{
+func NewRegistry() *Registry {
+	return &Registry{
 		diagnosticsSources: make(map[string]func() string),
 	}
 }
 
 // EnableServer enables the diagnostics server on the given port. Data will
 // be exposed on `/diagnostics` path in JSON format.
-func (r *DiagnosticsRegistry) EnableServer(port int) {
+func (r *Registry) EnableServer(port int) {
 	server := &http.Server{Addr: ":" + strconv.Itoa(port)}
 
 	http.HandleFunc("/diagnostics", func(response http.ResponseWriter, _ *http.Request) {
@@ -48,12 +48,12 @@ func (r *DiagnosticsRegistry) EnableServer(port int) {
 	}()
 }
 
-// Registers diagnostics source callback with a given name. 
+// RegisterSource registers diagnostics source callback with a given name.
 // Name will be used as a key and callback result as a value in JSON object
-// during composing diagnostics JSON. 
-// Note: function will override existing diagnostics source on attempt 
+// during composing diagnostics JSON.
+// Note: function will override existing diagnostics source on attempt
 // to register another one with the same name.
-func (r *DiagnosticsRegistry) RegisterSource(name string, source func() string) {
+func (r *Registry) RegisterSource(name string, source func() string) {
 	r.diagnosticsMutex.Lock()
 	defer r.diagnosticsMutex.Unlock()
 
@@ -61,7 +61,7 @@ func (r *DiagnosticsRegistry) RegisterSource(name string, source func() string) 
 }
 
 // Exposes all registered diagnostics sources in a single JSON document.
-func (r *DiagnosticsRegistry) exposeDiagnostics() string {
+func (r *Registry) exposeDiagnostics() string {
 	r.diagnosticsMutex.RLock()
 	defer r.diagnosticsMutex.RUnlock()
 

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,7 +1,7 @@
 // Package diagnostics provides some tools useful for gathering and
 // exposing arbitrary diagnositcs information for external monitoring tools.
 //
-// Possible usage: integration nodes list into dashboard
+// Possible usage: integration nodes list into dashboard.
 package diagnostics
 
 import (

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,4 +1,4 @@
-// Package `metrics` provides some tools useful for gathering and
+// Package metrics provides some tools useful for gathering and
 // exposing system metrics for external monitoring tools.
 //
 // Currently, this package is intended to use with Prometheus but

--- a/pkg/rate/limiter.go
+++ b/pkg/rate/limiter.go
@@ -59,6 +59,7 @@ func NewLimiter(
 	return l
 }
 
+// AcquirePermit acquires the permit
 func (l *Limiter) AcquirePermit() error {
 	ctx, cancel := context.WithTimeout(
 		context.Background(),
@@ -83,6 +84,7 @@ func (l *Limiter) AcquirePermit() error {
 	return nil
 }
 
+// ReleasePermit releases the permit
 func (l *Limiter) ReleasePermit() {
 	if l.semaphore != nil {
 		l.semaphore.Release(1)

--- a/pkg/rate/limiter.go
+++ b/pkg/rate/limiter.go
@@ -59,7 +59,7 @@ func NewLimiter(
 	return l
 }
 
-// AcquirePermit acquires the permit
+// AcquirePermit acquires the permit.
 func (l *Limiter) AcquirePermit() error {
 	ctx, cancel := context.WithTimeout(
 		context.Background(),
@@ -84,7 +84,7 @@ func (l *Limiter) AcquirePermit() error {
 	return nil
 }
 
-// ReleasePermit releases the permit
+// ReleasePermit releases the permit.
 func (l *Limiter) ReleasePermit() {
 	if l.semaphore != nil {
 		l.semaphore.Release(1)


### PR DESCRIPTION
As part of work on RFC-18 a job linting the Go code has been added to
`client.yml` workflow. Action for linting of Go code has been also added
(as separate repository) as part of this work.

Running the worklow with linting revealed a number of issues found
by the linter ([see here](https://github.com/keep-network/keep-common/runs/2379469245?check_suite_focus=true)).
All of them are also fixed as part of this PR.

@nkuba, after merging this PR into master please configure the
`client-lint` job in GitHub's settings as required for PR merging.