### PR TITLE
Added missing space in the transaction submission message

### DIFF
--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -13,13 +13,13 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	{{$logger}}.Debug(
 		"submitting transaction {{$method.LowerName}}",
 		{{if $method.Params -}}
-		"params: ",
+		" params: ",
 		fmt.Sprint(
 			{{$method.Params}}
 		),
 		{{end -}}
 		{{if $method.Payable -}}
-		"value: ", value,
+		" value: ", value,
 		{{- end}}
 	)
 

--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -68,8 +68,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	}
 
 	{{$logger}}.Infof(
-		"submitted transaction {{$method.LowerName}} with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
+		"submitted transaction {{$method.LowerName}} with id: [%s] and nonce [%v]",
+		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
@@ -101,8 +101,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			}
 
 			{{$logger}}.Infof(
-				"submitted transaction {{$method.LowerName}} with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
+				"submitted transaction {{$method.LowerName}} with id: [%s] and nonce [%v]",
+				transaction.Hash(),
 				transaction.Nonce(),
 			)
 

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -16,13 +16,13 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	{{$logger}}.Debug(
 		"submitting transaction {{$method.LowerName}}",
 		{{if $method.Params -}}
-		"params: ",
+		" params: ",
 		fmt.Sprint(
 			{{$method.Params}}
 		),
 		{{end -}}
 		{{if $method.Payable -}}
-		"value: ", value,
+		" value: ", value,
 		{{- end}}
 	)
 

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -71,8 +71,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	}
 
 	{{$logger}}.Infof(
-		"submitted transaction {{$method.LowerName}} with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
+		"submitted transaction {{$method.LowerName}} with id: [%s] and nonce [%v]",
+		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
@@ -104,8 +104,8 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			}
 
 			{{$logger}}.Infof(
-				"submitted transaction {{$method.LowerName}} with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
+				"submitted transaction {{$method.LowerName}} with id: [%s] and nonce [%v]",
+				transaction.Hash(),
 				transaction.Nonce(),
 			)
 


### PR DESCRIPTION
The logged message didn't contain a space between method name and params (resulted in e.g. `submitPublicKeyparams:`). 
In this PR we added a space.

Sample message that used to be logged:
```
2021-06-01T16:03:57.284+0200	DEBUG	keep-contract-BondedECDSAKeep	submitting transaction submitPublicKeyparams: [49 219 244 160 164 177 151 147 225 55 231 231 13 50 114 78 174 57 148 142 172 39 121 149 129 195 214 68 39 231 163 221 134 243 60 24 160 47 117 146 221 39 240 12 61 223 158 199 217 56 123 186 74 106 19 207 204 16 203 241 234 62 64 254]
```

The second commit we included in this PR is a simplification. As `Hash` type implements the` String()` function we can use `%s` in logger message format to log the value as hexadecimal string.