### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2