### PR TITLE
Adding cron for daily tests and builds on Mercodee

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,6 +1,8 @@
 name: Go
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
@@ -31,6 +33,7 @@ jobs:
         run: gotestsum
 
   client-scan:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,6 +42,7 @@ jobs:
           args: ./...
 
   client-lint:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.