### PR TITLE
Support EIP-1559 in the mining waiter

### DIFF
--- a/pkg/chain/celo/celoutil/adapter.go
+++ b/pkg/chain/celo/celoutil/adapter.go
@@ -24,7 +24,6 @@ func (ea *ethlikeAdapter) BlockByNumber(
 	return &ethlike.Block{
 		Header: &ethlike.Header{
 			Number: block.Number(),
-			// TODO: Set the base fee.
 		},
 	}, nil
 }

--- a/pkg/chain/celo/celoutil/adapter.go
+++ b/pkg/chain/celo/celoutil/adapter.go
@@ -24,6 +24,7 @@ func (ea *ethlikeAdapter) BlockByNumber(
 	return &ethlike.Block{
 		Header: &ethlike.Header{
 			Number: block.Number(),
+			// TODO: Set the base fee.
 		},
 	}, nil
 }

--- a/pkg/chain/celo/celoutil/adapter.go
+++ b/pkg/chain/celo/celoutil/adapter.go
@@ -77,24 +77,6 @@ func (sw *subscriptionWrapper) Err() <-chan error {
 	return sw.errChan
 }
 
-func (ea *ethlikeAdapter) TransactionReceipt(
-	ctx context.Context,
-	txHash ethlike.Hash,
-) (*ethlike.Receipt, error) {
-	receipt, err := ea.delegate.TransactionReceipt(
-		ctx,
-		common.Hash(txHash),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ethlike.Receipt{
-		Status:      receipt.Status,
-		BlockNumber: receipt.BlockNumber,
-	}, nil
-}
-
 func (ea *ethlikeAdapter) PendingNonceAt(
 	ctx context.Context,
 	account ethlike.Address,

--- a/pkg/chain/celo/celoutil/adapter_test.go
+++ b/pkg/chain/celo/celoutil/adapter_test.go
@@ -122,44 +122,6 @@ func TestEthlikeAdapter_SubscribeNewHead(t *testing.T) {
 	}
 }
 
-func TestEthlikeAdapter_TransactionReceipt(t *testing.T) {
-	var hash [32]byte
-	copy(hash[:], []byte{255})
-
-	client := &mockAdaptedCeloClient{
-		transactions: map[common.Hash]*types.Receipt{
-			common.BytesToHash(hash[:]): {
-				Status:      1,
-				BlockNumber: big.NewInt(100),
-			},
-		},
-	}
-
-	adapter := &ethlikeAdapter{client}
-
-	receipt, err := adapter.TransactionReceipt(
-		context.Background(),
-		hash,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedReceipt := &ethlike.Receipt{
-		Status:      1,
-		BlockNumber: big.NewInt(100),
-	}
-	if !reflect.DeepEqual(expectedReceipt, receipt) {
-		t.Errorf(
-			"unexpected tx receipt\n"+
-				"expected: [%+v]\n"+
-				"actual:   [%+v]",
-			expectedReceipt,
-			receipt,
-		)
-	}
-}
-
 func TestEthlikeAdapter_PendingNonceAt(t *testing.T) {
 	var address [20]byte
 	copy(address[:], []byte{255})

--- a/pkg/chain/celo/celoutil/adapter_test.go
+++ b/pkg/chain/celo/celoutil/adapter_test.go
@@ -154,9 +154,9 @@ func TestEthlikeAdapter_PendingNonceAt(t *testing.T) {
 type mockAdaptedCeloClient struct {
 	*mockCeloClient
 
-	blocks       []*big.Int
-	transactions map[common.Hash]*types.Receipt
-	nonces       map[common.Address]uint64
+	blocks  []*big.Int
+	receipt *types.Receipt
+	nonces  map[common.Address]uint64
 }
 
 func (macc *mockAdaptedCeloClient) BlockByNumber(
@@ -194,11 +194,7 @@ func (macc *mockAdaptedCeloClient) TransactionReceipt(
 	ctx context.Context,
 	txHash common.Hash,
 ) (*types.Receipt, error) {
-	if tx, ok := macc.transactions[txHash]; ok {
-		return tx, nil
-	}
-
-	return nil, fmt.Errorf("no tx with given hash")
+	return macc.receipt, nil
 }
 
 func (macc *mockAdaptedCeloClient) PendingNonceAt(

--- a/pkg/chain/celo/celoutil/adapter_test.go
+++ b/pkg/chain/celo/celoutil/adapter_test.go
@@ -154,9 +154,8 @@ func TestEthlikeAdapter_PendingNonceAt(t *testing.T) {
 type mockAdaptedCeloClient struct {
 	*mockCeloClient
 
-	blocks  []*big.Int
-	receipt *types.Receipt
-	nonces  map[common.Address]uint64
+	blocks []*big.Int
+	nonces map[common.Address]uint64
 }
 
 func (macc *mockAdaptedCeloClient) BlockByNumber(
@@ -188,13 +187,6 @@ func (macc *mockAdaptedCeloClient) SubscribeNewHead(
 		unsubscribeFn: func() {},
 		errChan:       make(chan error),
 	}, nil
-}
-
-func (macc *mockAdaptedCeloClient) TransactionReceipt(
-	ctx context.Context,
-	txHash common.Hash,
-) (*types.Receipt, error) {
-	return macc.receipt, nil
 }
 
 func (macc *mockAdaptedCeloClient) PendingNonceAt(

--- a/pkg/chain/celo/celoutil/celoutil.go
+++ b/pkg/chain/celo/celoutil/celoutil.go
@@ -211,12 +211,12 @@ func NewBlockCounter(client CeloClient) (*ethlike.BlockCounter, error) {
 func NewMiningWaiter(
 	client CeloClient,
 	checkInterval time.Duration,
-	maxGasPrice *big.Int,
+	maxGasFeeCap *big.Int,
 ) *ethlike.MiningWaiter {
 	return ethlike.NewMiningWaiter(
 		&ethlikeAdapter{client},
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 }
 

--- a/pkg/chain/celo/celoutil/celoutil.go
+++ b/pkg/chain/celo/celoutil/celoutil.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
-	"math/big"
-	"time"
-
 	"github.com/celo-org/celo-blockchain"
 	"github.com/celo-org/celo-blockchain/accounts/abi"
 	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
@@ -19,6 +15,8 @@ import (
 	"github.com/celo-org/celo-blockchain/rpc"
 	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-common/pkg/chain/ethlike"
+	"io/ioutil"
+	"math/big"
 )
 
 var logger = log.Logger("keep-celoutil")
@@ -203,21 +201,6 @@ func EstimateGas(
 // Celo client.
 func NewBlockCounter(client CeloClient) (*ethlike.BlockCounter, error) {
 	return ethlike.CreateBlockCounter(&ethlikeAdapter{client})
-}
-
-// NewMiningWaiter creates a new MiningWaiter instance for the provided
-// Celo client. It accepts two parameters setting up monitoring rules
-// of the transaction mining status.
-func NewMiningWaiter(
-	client CeloClient,
-	checkInterval time.Duration,
-	maxGasFeeCap *big.Int,
-) *ethlike.MiningWaiter {
-	return ethlike.NewMiningWaiter(
-		&ethlikeAdapter{client},
-		checkInterval,
-		maxGasFeeCap,
-	)
 }
 
 // NewNonceManager creates NonceManager instance for the provided account

--- a/pkg/chain/celo/celoutil/mining_waiter.go
+++ b/pkg/chain/celo/celoutil/mining_waiter.go
@@ -180,7 +180,6 @@ func (mw *MiningWaiter) ForceMining(
 		// Copy transactor options.
 		newTransactorOptions := new(bind.TransactOpts)
 		*newTransactorOptions = *originalTransactorOptions
-		newTransactorOptions.GasLimit = originalTransaction.Gas()
 		newTransactorOptions.GasPrice = gasPrice
 
 		transaction, err = resubmitFn(newTransactorOptions)

--- a/pkg/chain/celo/celoutil/mining_waiter.go
+++ b/pkg/chain/celo/celoutil/mining_waiter.go
@@ -58,6 +58,9 @@ func NewMiningWaiter(
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
+	logger.Infof("using [%v] mining check interval", checkInterval)
+	logger.Infof("using [%v] wei max gas price", maxGasPrice)
+
 	return &MiningWaiter{
 		client,
 		checkInterval,

--- a/pkg/chain/celo/celoutil/mining_waiter.go
+++ b/pkg/chain/celo/celoutil/mining_waiter.go
@@ -1,0 +1,168 @@
+package celoutil
+
+import (
+	"context"
+	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"math/big"
+	"time"
+)
+
+// MiningWaiter allows to block the execution until the given transaction is
+// mined as well as monitor the transaction and bump up the gas price in case
+// it is not mined in the given timeout.
+type MiningWaiter struct {
+	client        CeloClient
+	checkInterval time.Duration
+	maxGasPrice   *big.Int
+}
+
+// NewMiningWaiter creates a new MiningWaiter instance for the provided
+// client backend. It accepts two parameters setting up monitoring rules of the
+// transaction mining status.
+//
+// Check interval is the time given for the transaction to be mined. If the
+// transaction is not mined within that time, the gas price is increased by
+// 20% and transaction is replaced with the one with a higher gas price.
+//
+// Max gas price specifies the maximum gas price the client is willing to pay
+// for the transaction to be mined. The offered transaction gas price can not
+// be higher than this value. If the maximum allowed gas price is reached, no
+// further resubmission attempts are performed.
+func NewMiningWaiter(
+	client CeloClient,
+	checkInterval time.Duration,
+	maxGasPrice *big.Int,
+) *MiningWaiter {
+	return &MiningWaiter{
+		client,
+		checkInterval,
+		maxGasPrice,
+	}
+}
+
+// waitMined blocks the current execution until the transaction with the given
+// hash is mined. Execution is blocked until the transaction is mined or until
+// the given timeout passes.
+func (mw *MiningWaiter) waitMined(
+	timeout time.Duration,
+	transaction *types.Transaction,
+) (*types.Receipt, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	queryTicker := time.NewTicker(time.Second)
+	defer queryTicker.Stop()
+
+	for {
+		receipt, _ := mw.client.TransactionReceipt(
+			context.TODO(),
+			transaction.Hash(),
+		)
+		if receipt != nil {
+			return receipt, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-queryTicker.C:
+		}
+	}
+}
+
+// ResubmitTransactionFn implements the code for resubmitting the transaction
+// with the higher gas price. It should guarantee the same nonce is used for
+// transaction resubmission.
+type ResubmitTransactionFn func(
+	newTransactorOptions *bind.TransactOpts,
+) (*types.Transaction, error)
+
+// ForceMining blocks until the transaction is mined and bumps up the gas price
+// by 20% in the intervals defined by MiningWaiter in case the transaction has
+// not been mined yet. It accepts the original transaction reference and the
+// function responsible for executing transaction resubmission.
+func (mw *MiningWaiter) ForceMining(
+	originalTransaction *types.Transaction,
+	originalTransactorOptions *bind.TransactOpts,
+	resubmitFn ResubmitTransactionFn,
+) {
+	// If the original transaction's gas price was higher or equal the max
+	// allowed we do nothing; we need to wait for it to be mined.
+	if originalTransaction.GasPrice().Cmp(mw.maxGasPrice) >= 0 {
+		logger.Infof(
+			"original transaction gas price is higher than the max allowed; " +
+				"skipping resubmissions",
+		)
+		return
+	}
+
+	transaction := originalTransaction
+	for {
+		receipt, err := mw.waitMined(mw.checkInterval, transaction)
+		if err != nil {
+			logger.Infof(
+				"transaction [%v] not yet mined: [%v]",
+				transaction.Hash().TerminalString(),
+				err,
+			)
+		}
+
+		// Transaction mined, we are good.
+		if receipt != nil {
+			logger.Infof(
+				"transaction [%v] mined with status [%v] at block [%v]",
+				transaction.Hash().TerminalString(),
+				receipt.Status,
+				receipt.BlockNumber,
+			)
+			return
+		}
+
+		// Transaction not yet mined, if the previous gas price was the maximum
+		// one, we no longer resubmit.
+		gasPrice := transaction.GasPrice()
+		if gasPrice.Cmp(mw.maxGasPrice) == 0 {
+			logger.Infof(
+				"reached the maximum allowed gas price; " +
+					"stopping resubmissions",
+			)
+			return
+		}
+
+		// If we still have some margin, add 20% to the previous gas price.
+		twentyPercent := new(big.Int).Div(gasPrice, big.NewInt(5))
+		gasPrice = new(big.Int).Add(gasPrice, twentyPercent)
+
+		// If we reached the maximum allowed gas price, submit one more time
+		// with the maximum.
+		if gasPrice.Cmp(mw.maxGasPrice) > 0 {
+			gasPrice = mw.maxGasPrice
+		}
+
+		// Transaction not yet mined and we are still under the maximum allowed
+		// gas price; resubmitting transaction with 20% higher gas price
+		// evaluated earlier.
+		logger.Infof(
+			"resubmitting previous transaction [%v] "+
+				"with a higher gas price [%v]",
+			transaction.Hash().TerminalString(),
+			gasPrice,
+		)
+
+		// Copy transactor options.
+		newTransactorOptions := new(bind.TransactOpts)
+		*newTransactorOptions = *originalTransactorOptions
+		newTransactorOptions.GasLimit = originalTransaction.Gas()
+		newTransactorOptions.GasPrice = gasPrice
+
+		transaction, err = resubmitFn(newTransactorOptions)
+		if err != nil {
+			logger.Warningf(
+				"could not resubmit TX with a higher gas price: [%v]",
+				err,
+			)
+			return
+		}
+	}
+}

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -2,6 +2,7 @@ package celoutil
 
 import (
 	"bytes"
+	"context"
 	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/core/types"
@@ -26,7 +27,7 @@ var originalTransactorOptions = &bind.TransactOpts{
 func TestForceMining_NoResubmission(t *testing.T) {
 	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
 
-	chain := &mockAdaptedCeloClient{}
+	chain := &mockAdaptedCeloClientWithReceipt{}
 
 	var resubmissions []*bind.TransactOpts
 
@@ -56,7 +57,7 @@ func TestForceMining_NoResubmission(t *testing.T) {
 func TestForceMining_OneResubmission(t *testing.T) {
 	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
 
-	chain := &mockAdaptedCeloClient{}
+	chain := &mockAdaptedCeloClientWithReceipt{}
 
 	var resubmissions []*bind.TransactOpts
 
@@ -104,7 +105,7 @@ func TestForceMining_OneResubmission(t *testing.T) {
 func TestForceMining_MultipleAttempts(t *testing.T) {
 	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
 
-	chain := &mockAdaptedCeloClient{}
+	chain := &mockAdaptedCeloClientWithReceipt{}
 
 	var resubmissions []*bind.TransactOpts
 
@@ -172,7 +173,7 @@ func TestForceMining_MultipleAttempts(t *testing.T) {
 func TestForceMining_MaxAllowedPriceReached(t *testing.T) {
 	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
 
-	chain := &mockAdaptedCeloClient{}
+	chain := &mockAdaptedCeloClientWithReceipt{}
 
 	var resubmissions []*bind.TransactOpts
 
@@ -239,7 +240,7 @@ func TestForceMining_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
 	// is 45 Gwei
 	originalTransaction := createTransaction(big.NewInt(46000000000))
 
-	chain := &mockAdaptedCeloClient{}
+	chain := &mockAdaptedCeloClientWithReceipt{}
 
 	var resubmissions []*bind.TransactOpts
 
@@ -292,4 +293,17 @@ func createTransaction(gasPrice *big.Int) *types.Transaction {
 		nil,
 		[]byte{},
 	)
+}
+
+type mockAdaptedCeloClientWithReceipt struct {
+	*mockAdaptedCeloClient
+
+	receipt *types.Receipt
+}
+
+func (maccwr *mockAdaptedCeloClientWithReceipt) TransactionReceipt(
+	ctx context.Context,
+	txHash common.Hash,
+) (*types.Receipt, error) {
+	return maccwr.receipt, nil
 }

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -5,14 +5,18 @@ import (
 	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/keep-network/keep-common/pkg/chain/celo"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"math/big"
 	"testing"
-	"time"
 )
 
-const checkInterval = 100 * time.Millisecond
-
-var maxGasFeeCap = big.NewInt(45000000000) // 45 Gwei
+var config = celo.Config{
+	Config: ethlike.Config{
+		MiningCheckInterval: 1,
+	},
+	MaxGasPrice: celo.WrapWei(big.NewInt(45000000000)), // 45 Gwei
+}
 
 var originalTransactorOptions = &bind.TransactOpts{
 	From:  common.BytesToAddress([]byte{0x01}),
@@ -36,11 +40,7 @@ func TestForceMining_NoResubmission(t *testing.T) {
 	// receipt is already there
 	chain.receipt = &types.Receipt{}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -69,11 +69,7 @@ func TestForceMining_OneResubmission(t *testing.T) {
 		return createTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -132,11 +128,7 @@ func TestForceMining_MultipleAttempts(t *testing.T) {
 		return createTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -201,11 +193,7 @@ func TestForceMining_MaxAllowedPriceReached(t *testing.T) {
 		return createTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -263,11 +251,7 @@ func TestForceMining_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
 		return createTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -1,0 +1,311 @@
+package celoutil
+
+import (
+	"bytes"
+	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"math/big"
+	"testing"
+	"time"
+)
+
+const checkInterval = 100 * time.Millisecond
+
+var maxGasFeeCap = big.NewInt(45000000000) // 45 Gwei
+
+var originalTransactorOptions = &bind.TransactOpts{
+	From:  common.BytesToAddress([]byte{0x01}),
+	Nonce: big.NewInt(100),
+}
+
+func TestForceMining_NoResubmission(t *testing.T) {
+	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
+
+	chain := &mockAdaptedCeloClient{}
+
+	var resubmissions []*bind.TransactOpts
+
+	resubmitFn := func(
+		newTransactorOptions *bind.TransactOpts,
+	) (*types.Transaction, error) {
+		resubmissions = append(resubmissions, newTransactorOptions)
+		return createTransaction(newTransactorOptions.GasPrice), nil
+	}
+
+	// receipt is already there
+	chain.receipt = &types.Receipt{}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		originalTransactorOptions,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissions)
+	if resubmissionCount != 0 {
+		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
+	}
+}
+
+func TestForceMining_OneResubmission(t *testing.T) {
+	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
+
+	chain := &mockAdaptedCeloClient{}
+
+	var resubmissions []*bind.TransactOpts
+
+	resubmitFn := func(
+		newTransactorOptions *bind.TransactOpts,
+	) (*types.Transaction, error) {
+		resubmissions = append(resubmissions, newTransactorOptions)
+		// first resubmission succeeded
+		chain.receipt = &types.Receipt{}
+		return createTransaction(newTransactorOptions.GasPrice), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		originalTransactorOptions,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissions)
+	if resubmissionCount != 1 {
+		t.Fatalf("expected one resubmission; has: [%v]", resubmissionCount)
+	}
+
+	resubmission := resubmissions[0]
+
+	assertTransactionOptionsInvariants(t, resubmission)
+
+	if resubmission.GasLimit != originalTransaction.Gas() {
+		t.Fatalf("gas limit should be the same as in original transaction")
+	}
+
+	expectedGasPrice := big.NewInt(24000000000)
+	if resubmission.GasPrice.Cmp(expectedGasPrice) != 0 {
+		t.Fatalf(
+			"unexpected gas price value\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedGasPrice,
+			resubmission.GasPrice,
+		)
+	}
+}
+
+func TestForceMining_MultipleAttempts(t *testing.T) {
+	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
+
+	chain := &mockAdaptedCeloClient{}
+
+	var resubmissions []*bind.TransactOpts
+
+	expectedAttempts := 3
+	expectedResubmissionGasPrices := []*big.Int{
+		big.NewInt(24000000000), // + 20%
+		big.NewInt(28800000000), // + 20%
+		big.NewInt(34560000000), // + 20%
+	}
+
+	attemptsSoFar := 1
+	resubmitFn := func(
+		newTransactorOptions *bind.TransactOpts,
+	) (*types.Transaction, error) {
+		resubmissions = append(resubmissions, newTransactorOptions)
+		if attemptsSoFar == expectedAttempts {
+			chain.receipt = &types.Receipt{}
+		} else {
+			attemptsSoFar++
+		}
+		return createTransaction(newTransactorOptions.GasPrice), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		originalTransactorOptions,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissions)
+	if resubmissionCount != expectedAttempts {
+		t.Fatalf(
+			"expected [%v] resubmission; has: [%v]",
+			expectedAttempts,
+			resubmissionCount,
+		)
+	}
+
+	for index, resubmission := range resubmissions {
+		assertTransactionOptionsInvariants(t, resubmission)
+
+		if resubmission.GasLimit != originalTransaction.Gas() {
+			t.Fatalf(
+				"resubmission [%v] gas limit should be the same as in "+
+					"original transaction",
+				index,
+			)
+		}
+
+		price := resubmission.GasPrice
+		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v] gas price\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedResubmissionGasPrices[index],
+				price,
+			)
+		}
+	}
+}
+
+func TestForceMining_MaxAllowedPriceReached(t *testing.T) {
+	originalTransaction := createTransaction(big.NewInt(20000000000)) // 20 Gwei
+
+	chain := &mockAdaptedCeloClient{}
+
+	var resubmissions []*bind.TransactOpts
+
+	expectedAttempts := 5
+	expectedResubmissionGasPrices := []*big.Int{
+		big.NewInt(24000000000), // + 20%
+		big.NewInt(28800000000), // + 20%
+		big.NewInt(34560000000), // + 20%
+		big.NewInt(41472000000), // + 20%
+		big.NewInt(45000000000), // max allowed
+	}
+
+	resubmitFn := func(
+		newTransactorOptions *bind.TransactOpts,
+	) (*types.Transaction, error) {
+		resubmissions = append(resubmissions, newTransactorOptions)
+		// not setting mockBackend.receipt, mining takes a very long time
+		return createTransaction(newTransactorOptions.GasPrice), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		originalTransactorOptions,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissions)
+	if resubmissionCount != expectedAttempts {
+		t.Fatalf(
+			"expected [%v] resubmission; has: [%v]",
+			expectedAttempts,
+			resubmissionCount,
+		)
+	}
+
+	for index, resubmission := range resubmissions {
+		assertTransactionOptionsInvariants(t, resubmission)
+
+		if resubmission.GasLimit != originalTransaction.Gas() {
+			t.Fatalf(
+				"resubmission [%v] gas limit should be the same as in "+
+					"original transaction",
+				index,
+			)
+		}
+
+		price := resubmission.GasPrice
+		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v] gas price\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedResubmissionGasPrices[index],
+				price,
+			)
+		}
+	}
+}
+
+func TestForceMining_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
+	// original transaction was priced at 46 Gwei, the maximum allowed gas price
+	// is 45 Gwei
+	originalTransaction := createTransaction(big.NewInt(46000000000))
+
+	chain := &mockAdaptedCeloClient{}
+
+	var resubmissions []*bind.TransactOpts
+
+	resubmitFn := func(
+		newTransactorOptions *bind.TransactOpts,
+	) (*types.Transaction, error) {
+		resubmissions = append(resubmissions, newTransactorOptions)
+		// not setting mockBackend.receipt, mining takes a very long time
+		return createTransaction(newTransactorOptions.GasPrice), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		originalTransactorOptions,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissions)
+	if resubmissionCount != 0 {
+		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
+	}
+}
+
+func assertTransactionOptionsInvariants(
+	t *testing.T,
+	newTransactionOptions *bind.TransactOpts,
+) {
+	if !bytes.Equal(
+		newTransactionOptions.From.Bytes(),
+		originalTransactorOptions.From.Bytes(),
+	) {
+		t.Fatalf("from address should remain unchanged")
+	}
+
+	if newTransactionOptions.Nonce.Cmp(originalTransactorOptions.Nonce) != 0 {
+		t.Fatalf("nonce should remain unchanged")
+	}
+}
+
+func createTransaction(gasPrice *big.Int) *types.Transaction {
+	return types.NewTransaction(
+		0,
+		common.Address{},
+		nil,
+		25000,
+		gasPrice,
+		nil,
+		nil,
+		nil,
+		[]byte{},
+	)
+}

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -88,6 +88,7 @@ func TestForceMining_OneResubmission(t *testing.T) {
 		t.Fatalf("gas limit should be the same as in original transaction")
 	}
 
+	// The original gas price should be bumped up by 20% and be equal to 24 Gwei.
 	expectedGasPrice := big.NewInt(24000000000)
 	if resubmission.GasPrice.Cmp(expectedGasPrice) != 0 {
 		t.Fatalf(

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -84,10 +84,6 @@ func TestForceMining_OneResubmission(t *testing.T) {
 
 	assertNonceUnchanged(t, resubmission)
 
-	if resubmission.GasLimit != originalTransaction.Gas() {
-		t.Fatalf("gas limit should be the same as in original transaction")
-	}
-
 	// The original gas price should be bumped up by 20% and be equal to 24 Gwei.
 	expectedGasPrice := big.NewInt(24000000000)
 	if resubmission.GasPrice.Cmp(expectedGasPrice) != 0 {
@@ -147,14 +143,6 @@ func TestForceMining_MultipleAttempts(t *testing.T) {
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
 
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
-
 		price := resubmission.GasPrice
 		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {
 			t.Fatalf(
@@ -211,14 +199,6 @@ func TestForceMining_MaxAllowedPriceReached(t *testing.T) {
 
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
-
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
 
 		price := resubmission.GasPrice
 		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {

--- a/pkg/chain/celo/celoutil/mining_waiter_test.go
+++ b/pkg/chain/celo/celoutil/mining_waiter_test.go
@@ -1,7 +1,6 @@
 package celoutil
 
 import (
-	"bytes"
 	"context"
 	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
 	"github.com/celo-org/celo-blockchain/common"
@@ -20,7 +19,6 @@ var config = celo.Config{
 }
 
 var originalTransactorOptions = &bind.TransactOpts{
-	From:  common.BytesToAddress([]byte{0x01}),
 	Nonce: big.NewInt(100),
 }
 
@@ -84,7 +82,7 @@ func TestForceMining_OneResubmission(t *testing.T) {
 
 	resubmission := resubmissions[0]
 
-	assertTransactionOptionsInvariants(t, resubmission)
+	assertNonceUnchanged(t, resubmission)
 
 	if resubmission.GasLimit != originalTransaction.Gas() {
 		t.Fatalf("gas limit should be the same as in original transaction")
@@ -146,7 +144,7 @@ func TestForceMining_MultipleAttempts(t *testing.T) {
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -211,7 +209,7 @@ func TestForceMining_MaxAllowedPriceReached(t *testing.T) {
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -265,17 +263,10 @@ func TestForceMining_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
 	}
 }
 
-func assertTransactionOptionsInvariants(
+func assertNonceUnchanged(
 	t *testing.T,
 	newTransactionOptions *bind.TransactOpts,
 ) {
-	if !bytes.Equal(
-		newTransactionOptions.From.Bytes(),
-		originalTransactorOptions.From.Bytes(),
-	) {
-		t.Fatalf("from address should remain unchanged")
-	}
-
 	if newTransactionOptions.Nonce.Cmp(originalTransactorOptions.Nonce) != 0 {
 		t.Fatalf("nonce should remain unchanged")
 	}

--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -15,7 +15,9 @@ type Config struct {
 	// willing to pay for the transaction to be mined. The offered transaction
 	// gas cost can not be higher than the max gas fee cap value. If the maximum
 	// allowed gas fee cap is reached, no further resubmission attempts are
-	// performed.
+	// performed. This value is used for all types of Ethereum transactions.
+	// For legacy transactions, this value works as a maximum gas price
+	// and for EIP-1559 transactions, this value works as max gas fee cap.
 	MaxGasFeeCap *Wei
 
 	// BalanceAlertThreshold defines a minimum value of the operator's

--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -11,12 +11,12 @@ import (
 type Config struct {
 	ethlike.Config
 
-	// MaxGasPrice specifies the maximum gas price the client is
+	// MaxGasFeeCap specifies the maximum gas fee cap the client is
 	// willing to pay for the transaction to be mined. The offered transaction
-	// gas price can not be higher than the max gas price value. If the maximum
-	// allowed gas price is reached, no further resubmission attempts are
+	// gas cost can not be higher than the max gas fee cap value. If the maximum
+	// allowed gas fee cap is reached, no further resubmission attempts are
 	// performed.
-	MaxGasPrice *Wei
+	MaxGasFeeCap *Wei
 
 	// BalanceAlertThreshold defines a minimum value of the operator's
 	// account balance below which an alert will be triggered.

--- a/pkg/chain/ethereum/ethutil/adapter.go
+++ b/pkg/chain/ethereum/ethutil/adapter.go
@@ -23,7 +23,8 @@ func (ea *ethlikeAdapter) BlockByNumber(
 
 	return &ethlike.Block{
 		Header: &ethlike.Header{
-			Number: block.Number(),
+			Number:  block.Number(),
+			BaseFee: block.Header().BaseFee,
 		},
 	}, nil
 }

--- a/pkg/chain/ethereum/ethutil/adapter.go
+++ b/pkg/chain/ethereum/ethutil/adapter.go
@@ -23,8 +23,7 @@ func (ea *ethlikeAdapter) BlockByNumber(
 
 	return &ethlike.Block{
 		Header: &ethlike.Header{
-			Number:  block.Number(),
-			BaseFee: block.Header().BaseFee,
+			Number: block.Number(),
 		},
 	}, nil
 }
@@ -75,24 +74,6 @@ func (sw *subscriptionWrapper) Unsubscribe() {
 
 func (sw *subscriptionWrapper) Err() <-chan error {
 	return sw.errChan
-}
-
-func (ea *ethlikeAdapter) TransactionReceipt(
-	ctx context.Context,
-	txHash ethlike.Hash,
-) (*ethlike.Receipt, error) {
-	receipt, err := ea.delegate.TransactionReceipt(
-		ctx,
-		common.Hash(txHash),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ethlike.Receipt{
-		Status:      receipt.Status,
-		BlockNumber: receipt.BlockNumber,
-	}, nil
 }
 
 func (ea *ethlikeAdapter) PendingNonceAt(

--- a/pkg/chain/ethereum/ethutil/adapter_test.go
+++ b/pkg/chain/ethereum/ethutil/adapter_test.go
@@ -20,6 +20,11 @@ func TestEthlikeAdapter_BlockByNumber(t *testing.T) {
 			big.NewInt(1),
 			big.NewInt(2),
 		},
+		blocksBaseFee: []*big.Int{
+			big.NewInt(10),
+			big.NewInt(11),
+			big.NewInt(12),
+		},
 	}
 
 	adapter := &ethlikeAdapter{client}
@@ -122,44 +127,6 @@ func TestEthlikeAdapter_SubscribeNewHead(t *testing.T) {
 	}
 }
 
-func TestEthlikeAdapter_TransactionReceipt(t *testing.T) {
-	var hash [32]byte
-	copy(hash[:], []byte{255})
-
-	client := &mockAdaptedEthereumClient{
-		transactions: map[common.Hash]*types.Receipt{
-			common.BytesToHash(hash[:]): {
-				Status:      1,
-				BlockNumber: big.NewInt(100),
-			},
-		},
-	}
-
-	adapter := &ethlikeAdapter{client}
-
-	receipt, err := adapter.TransactionReceipt(
-		context.Background(),
-		hash,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedReceipt := &ethlike.Receipt{
-		Status:      1,
-		BlockNumber: big.NewInt(100),
-	}
-	if !reflect.DeepEqual(expectedReceipt, receipt) {
-		t.Errorf(
-			"unexpected tx receipt\n"+
-				"expected: [%+v]\n"+
-				"actual:   [%+v]",
-			expectedReceipt,
-			receipt,
-		)
-	}
-}
-
 func TestEthlikeAdapter_PendingNonceAt(t *testing.T) {
 	var address [20]byte
 	copy(address[:], []byte{255})
@@ -192,9 +159,10 @@ func TestEthlikeAdapter_PendingNonceAt(t *testing.T) {
 type mockAdaptedEthereumClient struct {
 	*mockEthereumClient
 
-	blocks       []*big.Int
-	transactions map[common.Hash]*types.Receipt
-	nonces       map[common.Address]uint64
+	blocks        []*big.Int
+	blocksBaseFee []*big.Int
+	receipt       *types.Receipt
+	nonces        map[common.Address]uint64
 }
 
 func (maec *mockAdaptedEthereumClient) BlockByNumber(
@@ -208,7 +176,10 @@ func (maec *mockAdaptedEthereumClient) BlockByNumber(
 	}
 
 	return types.NewBlockWithHeader(
-		&types.Header{Number: maec.blocks[index]},
+		&types.Header{
+			Number:  maec.blocks[index],
+			BaseFee: maec.blocksBaseFee[index],
+		},
 	), nil
 }
 
@@ -232,11 +203,7 @@ func (maec *mockAdaptedEthereumClient) TransactionReceipt(
 	ctx context.Context,
 	txHash common.Hash,
 ) (*types.Receipt, error) {
-	if tx, ok := maec.transactions[txHash]; ok {
-		return tx, nil
-	}
-
-	return nil, fmt.Errorf("no tx with given hash")
+	return maec.receipt, nil
 }
 
 func (maec *mockAdaptedEthereumClient) PendingNonceAt(

--- a/pkg/chain/ethereum/ethutil/adapter_test.go
+++ b/pkg/chain/ethereum/ethutil/adapter_test.go
@@ -161,7 +161,6 @@ type mockAdaptedEthereumClient struct {
 
 	blocks        []*big.Int
 	blocksBaseFee []*big.Int
-	receipt       *types.Receipt
 	nonces        map[common.Address]uint64
 }
 
@@ -197,13 +196,6 @@ func (maec *mockAdaptedEthereumClient) SubscribeNewHead(
 		unsubscribeFn: func() {},
 		errChan:       make(chan error),
 	}, nil
-}
-
-func (maec *mockAdaptedEthereumClient) TransactionReceipt(
-	ctx context.Context,
-	txHash common.Hash,
-) (*types.Receipt, error) {
-	return maec.receipt, nil
 }
 
 func (maec *mockAdaptedEthereumClient) PendingNonceAt(

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -6,11 +6,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"io/ioutil"
 	"math/big"
-	"time"
-
-	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 
 	"github.com/ipfs/go-log"
 
@@ -191,21 +189,6 @@ func EstimateGas(
 // Ethereum client.
 func NewBlockCounter(client EthereumClient) (*ethlike.BlockCounter, error) {
 	return ethlike.CreateBlockCounter(&ethlikeAdapter{client})
-}
-
-// NewMiningWaiter creates a new MiningWaiter instance for the provided
-// Ethereum client. It accepts two parameters setting up monitoring rules
-// of the transaction mining status.
-func NewMiningWaiter(
-	client EthereumClient,
-	checkInterval time.Duration,
-	maxGasFeeCap *big.Int,
-) *ethlike.MiningWaiter {
-	return ethlike.NewMiningWaiter(
-		&ethlikeAdapter{client},
-		checkInterval,
-		maxGasFeeCap,
-	)
 }
 
 // NewNonceManager creates NonceManager instance for the provided account

--- a/pkg/chain/ethereum/ethutil/ethutil.go
+++ b/pkg/chain/ethereum/ethutil/ethutil.go
@@ -199,12 +199,12 @@ func NewBlockCounter(client EthereumClient) (*ethlike.BlockCounter, error) {
 func NewMiningWaiter(
 	client EthereumClient,
 	checkInterval time.Duration,
-	maxGasPrice *big.Int,
+	maxGasFeeCap *big.Int,
 ) *ethlike.MiningWaiter {
 	return ethlike.NewMiningWaiter(
 		&ethlikeAdapter{client},
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 }
 

--- a/pkg/chain/ethereum/ethutil/mining_waiter.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter.go
@@ -66,6 +66,9 @@ func NewMiningWaiter(
 		maxGasFeeCap = config.MaxGasFeeCap.Int
 	}
 
+	logger.Infof("using [%v] mining check interval", checkInterval)
+	logger.Infof("using [%v] wei max gas fee cap", maxGasFeeCap)
+
 	return &MiningWaiter{
 		client,
 		checkInterval,

--- a/pkg/chain/ethereum/ethutil/mining_waiter.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter.go
@@ -225,7 +225,6 @@ func (mw *MiningWaiter) forceMiningLegacyTx(
 		// Copy transactor options.
 		newTransactorOptions := new(bind.TransactOpts)
 		*newTransactorOptions = *originalTransactorOptions
-		newTransactorOptions.GasLimit = originalTransaction.Gas()
 		newTransactorOptions.GasPrice = gasPrice
 
 		transaction, err = resubmitFn(newTransactorOptions)
@@ -375,7 +374,6 @@ func (mw *MiningWaiter) forceMiningDynamicFeeTx(
 		// Copy transactor options.
 		newTransactorOptions := new(bind.TransactOpts)
 		*newTransactorOptions = *originalTransactorOptions
-		newTransactorOptions.GasLimit = originalTransaction.Gas()
 		newTransactorOptions.GasFeeCap = newGasFeeCap
 		newTransactorOptions.GasTipCap = newGasTipCap
 

--- a/pkg/chain/ethereum/ethutil/mining_waiter.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter.go
@@ -397,7 +397,7 @@ func (mw *MiningWaiter) latestBaseFee() (*big.Int, error) {
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not get latest block: [%v]", err)
+		return nil, fmt.Errorf("could not get the latest block: [%v]", err)
 	}
 
 	baseFee := latestBlock.BaseFee()

--- a/pkg/chain/ethereum/ethutil/mining_waiter_test.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter_test.go
@@ -287,7 +287,9 @@ func TestForceMining_DynamicFee_NoResubmission(t *testing.T) {
 		originalGasTipCap,
 	)
 
-	chain := &mockAdaptedEthereumClientWithReceipt{}
+	chain := &mockAdaptedEthereumClientWithReceipt{
+		mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+	}
 
 	// Base fee remains unchanged.
 	chain.blocks = append(chain.blocks, big.NewInt(1))
@@ -370,7 +372,9 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 				originalGasTipCap,
 			)
 
-			chain := &mockAdaptedEthereumClientWithReceipt{}
+			chain := &mockAdaptedEthereumClientWithReceipt{
+				mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+			}
 
 			chain.blocks = append(chain.blocks, big.NewInt(1))
 			chain.blocksBaseFee = append(chain.blocksBaseFee, test.nextBaseFee)
@@ -449,7 +453,9 @@ func TestForceMining_DynamicFee_MultipleAttemps(t *testing.T) {
 		originalGasTipCap,
 	)
 
-	chain := &mockAdaptedEthereumClientWithReceipt{}
+	chain := &mockAdaptedEthereumClientWithReceipt{
+		mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+	}
 
 	// Base fee remains unchanged.
 	chain.blocks = append(chain.blocks, big.NewInt(1))
@@ -555,7 +561,9 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
 		originalGasTipCap,
 	)
 
-	chain := &mockAdaptedEthereumClientWithReceipt{}
+	chain := &mockAdaptedEthereumClientWithReceipt{
+		mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+	}
 
 	// Massive increase of base fee to 30 Gwei. This is needed
 	// to exceed the maximum gas fee cap value.
@@ -642,7 +650,9 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReachedButBelowThreshold(t *testi
 		originalGasTipCap,
 	)
 
-	chain := &mockAdaptedEthereumClientWithReceipt{}
+	chain := &mockAdaptedEthereumClientWithReceipt{
+		mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+	}
 
 	// Base fee remains unchanged.
 	chain.blocks = append(chain.blocks, big.NewInt(1))
@@ -756,7 +766,9 @@ func TestForceMining_DynamicFee_OriginalPriceHigherThanMaxAllowed(t *testing.T) 
 		originalGasTipCap,
 	)
 
-	chain := &mockAdaptedEthereumClientWithReceipt{}
+	chain := &mockAdaptedEthereumClientWithReceipt{
+		mockAdaptedEthereumClient: &mockAdaptedEthereumClient{},
+	}
 
 	// Base fee remains unchanged.
 	chain.blocks = append(chain.blocks, big.NewInt(1))

--- a/pkg/chain/ethereum/ethutil/mining_waiter_test.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter_test.go
@@ -84,10 +84,6 @@ func TestForceMining_Legacy_OneResubmission(t *testing.T) {
 
 	assertNonceUnchanged(t, resubmission)
 
-	if resubmission.GasLimit != originalTransaction.Gas() {
-		t.Fatalf("gas limit should be the same as in original transaction")
-	}
-
 	if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
 		t.Fatalf("gas fee and tip cap should be nil")
 	}
@@ -150,14 +146,6 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
 
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
-
 		if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
 			t.Fatalf("resubmission [%v] gas fee and tip cap should be nil", index)
 		}
@@ -218,14 +206,6 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
-
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
 
 		if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
 			t.Fatalf("resubmission [%v] gas fee and tip cap should be nil", index)
@@ -410,10 +390,6 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 
 			assertNonceUnchanged(t, resubmission)
 
-			if resubmission.GasLimit != originalTransaction.Gas() {
-				t.Fatalf("gas limit should be the same as in original transaction")
-			}
-
 			if resubmission.GasPrice != nil {
 				t.Fatalf("gas price should be nil")
 			}
@@ -511,14 +487,6 @@ func TestForceMining_DynamicFee_MultipleAttemps(t *testing.T) {
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
 
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
-
 		if resubmission.GasPrice != nil {
 			t.Fatalf("resubmission [%v] gas price should be nil", index)
 		}
@@ -606,10 +574,6 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
 	resubmission := resubmissions[0]
 
 	assertNonceUnchanged(t, resubmission)
-
-	if resubmission.GasLimit != originalTransaction.Gas() {
-		t.Fatalf("gas limit should be the same as in original transaction")
-	}
 
 	if resubmission.GasPrice != nil {
 		t.Fatalf("gas price should be nil")
@@ -717,14 +681,6 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReachedButBelowThreshold(t *testi
 
 	for index, resubmission := range resubmissions {
 		assertNonceUnchanged(t, resubmission)
-
-		if resubmission.GasLimit != originalTransaction.Gas() {
-			t.Fatalf(
-				"resubmission [%v] gas limit should be the same as in "+
-					"original transaction",
-				index,
-			)
-		}
 
 		if resubmission.GasPrice != nil {
 			t.Fatalf("resubmission [%v] gas price should be nil", index)

--- a/pkg/chain/ethereum/ethutil/mining_waiter_test.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter_test.go
@@ -5,14 +5,18 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"math/big"
 	"testing"
-	"time"
 )
 
-const checkInterval = 100 * time.Millisecond
-
-var maxGasFeeCap = big.NewInt(45000000000) // 45 Gwei
+var config = ethereum.Config{
+	Config: ethlike.Config{
+		MiningCheckInterval: 1,
+	},
+	MaxGasFeeCap: ethereum.WrapWei(big.NewInt(45000000000)), // 45 Gwei
+}
 
 var originalTransactorOptions = &bind.TransactOpts{
 	From:  common.BytesToAddress([]byte{0x01}),
@@ -36,11 +40,7 @@ func TestForceMining_Legacy_NoResubmission(t *testing.T) {
 	// receipt is already there
 	chain.receipt = &types.Receipt{}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -69,11 +69,7 @@ func TestForceMining_Legacy_OneResubmission(t *testing.T) {
 		return createLegacyTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -136,11 +132,7 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 		return createLegacyTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -209,11 +201,7 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 		return createLegacyTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -275,11 +263,7 @@ func TestForceMining_Legacy_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
 		return createLegacyTransaction(newTransactorOptions.GasPrice), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -323,11 +307,7 @@ func TestForceMining_DynamicFee_NoResubmission(t *testing.T) {
 	// Receipt is already there.
 	chain.receipt = &types.Receipt{}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -408,11 +388,7 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 				), nil
 			}
 
-			waiter := NewMiningWaiter(
-				chain,
-				checkInterval,
-				maxGasFeeCap,
-			)
+			waiter := NewMiningWaiter(chain, config)
 			waiter.ForceMining(
 				originalTransaction,
 				originalTransactorOptions,
@@ -511,11 +487,7 @@ func TestForceMining_DynamicFee_MultipleAttemps(t *testing.T) {
 		), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -605,11 +577,7 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
 		), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -718,11 +686,7 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReachedButBelowThreshold(t *testi
 		), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,
@@ -810,11 +774,7 @@ func TestForceMining_DynamicFee_OriginalPriceHigherThanMaxAllowed(t *testing.T) 
 		), nil
 	}
 
-	waiter := NewMiningWaiter(
-		chain,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	waiter := NewMiningWaiter(chain, config)
 	waiter.ForceMining(
 		originalTransaction,
 		originalTransactorOptions,

--- a/pkg/chain/ethereum/ethutil/mining_waiter_test.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter_test.go
@@ -335,7 +335,7 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 			// Base fee decreased to 5 Gwei.
 			nextBaseFee: big.NewInt(5000000000),
 			// Gas fee cap should be computed as: 2 * 5 Gwei + 4.8 Gwei = 14.8 Gwei.
-			// However, this value doesn't fulfill the required fee bump threshold.
+			// However, this value doesn't fulfill the required base fee bump threshold.
 			// In result, the new gas fee value should be bumped up by 10% to
 			// satisfy the condition: 24 Gwei * 1.1 = 26.4 Gwei
 			expectedGasFeeCap: big.NewInt(26400000000),
@@ -346,7 +346,7 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 			// Base fee remains 10 Gwei.
 			nextBaseFee: originalBaseFee,
 			// Gas fee cap should be computed as: 2 * 10 Gwei + 4.8 Gwei = 24.8 Gwei.
-			// However, this value doesn't fulfill the required fee bump threshold.
+			// However, this value doesn't fulfill the required base fee bump threshold.
 			// In result, the new gas fee value should be bumped up by 10% to
 			// satisfy the condition: 24 Gwei * 1.1 = 26.4 Gwei
 			expectedGasFeeCap: big.NewInt(26400000000),
@@ -591,6 +591,10 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
 		resubmitFn,
 	)
 
+	// The new gas fee value should be computed as usual:
+	// 2 * 30 Gwei + 4.8 gwei = 64.8 Gwei. However, this value exceeds the
+	// max gas fee cap value of 45 Gwei. In effect, one resubmission with the
+	// maximum value should be made.
 	resubmissionCount := len(resubmissions)
 	if resubmissionCount != 1 {
 		t.Fatalf(

--- a/pkg/chain/ethereum/ethutil/mining_waiter_test.go
+++ b/pkg/chain/ethereum/ethutil/mining_waiter_test.go
@@ -1,7 +1,6 @@
 package ethutil
 
 import (
-	"bytes"
 	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,7 +19,6 @@ var config = ethereum.Config{
 }
 
 var originalTransactorOptions = &bind.TransactOpts{
-	From:  common.BytesToAddress([]byte{0x01}),
 	Nonce: big.NewInt(100),
 }
 
@@ -84,7 +82,7 @@ func TestForceMining_Legacy_OneResubmission(t *testing.T) {
 
 	resubmission := resubmissions[0]
 
-	assertTransactionOptionsInvariants(t, resubmission)
+	assertNonceUnchanged(t, resubmission)
 
 	if resubmission.GasLimit != originalTransaction.Gas() {
 		t.Fatalf("gas limit should be the same as in original transaction")
@@ -150,7 +148,7 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -219,7 +217,7 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -410,7 +408,7 @@ func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
 
 			resubmission := resubmissions[0]
 
-			assertTransactionOptionsInvariants(t, resubmission)
+			assertNonceUnchanged(t, resubmission)
 
 			if resubmission.GasLimit != originalTransaction.Gas() {
 				t.Fatalf("gas limit should be the same as in original transaction")
@@ -511,7 +509,7 @@ func TestForceMining_DynamicFee_MultipleAttemps(t *testing.T) {
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -603,7 +601,7 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
 
 	resubmission := resubmissions[0]
 
-	assertTransactionOptionsInvariants(t, resubmission)
+	assertNonceUnchanged(t, resubmission)
 
 	if resubmission.GasLimit != originalTransaction.Gas() {
 		t.Fatalf("gas limit should be the same as in original transaction")
@@ -714,7 +712,7 @@ func TestForceMining_DynamicFee_MaxAllowedPriceReachedButBelowThreshold(t *testi
 	}
 
 	for index, resubmission := range resubmissions {
-		assertTransactionOptionsInvariants(t, resubmission)
+		assertNonceUnchanged(t, resubmission)
 
 		if resubmission.GasLimit != originalTransaction.Gas() {
 			t.Fatalf(
@@ -800,17 +798,10 @@ func TestForceMining_DynamicFee_OriginalPriceHigherThanMaxAllowed(t *testing.T) 
 	}
 }
 
-func assertTransactionOptionsInvariants(
+func assertNonceUnchanged(
 	t *testing.T,
 	newTransactionOptions *bind.TransactOpts,
 ) {
-	if !bytes.Equal(
-		newTransactionOptions.From.Bytes(),
-		originalTransactorOptions.From.Bytes(),
-	) {
-		t.Fatalf("from address should remain unchanged")
-	}
-
 	if newTransactionOptions.Nonce.Cmp(originalTransactorOptions.Nonce) != 0 {
 		t.Fatalf("nonce should remain unchanged")
 	}

--- a/pkg/chain/ethlike/chain.go
+++ b/pkg/chain/ethlike/chain.go
@@ -32,10 +32,35 @@ type Block struct {
 	*Header
 }
 
+// TxType represents an ETH-like transaction type.
+type TxType int
+
+// Possible ETH-like transaction types.
+const (
+	// LegacyTxType represents a pre EIP-1559 legacy transaction.
+	LegacyTxType TxType = iota
+	// AccessListTxType represents a EIP-2930 access list transaction.
+	AccessListTxType
+	// DynamicFeeTxType represents a post EIP-1559 dynamic fee transaction.
+	DynamicFeeTxType
+)
+
 // Transaction represents an ETH-like chain transaction.
 type Transaction struct {
-	Hash     Hash
+	// Transaction hash.
+	Hash Hash
+
+	// Gas price to use for legacy (pre EIP-1559) transaction.
 	GasPrice *big.Int
+
+	// Gas fee cap to use for the EIP-1559 transaction.
+	GasFeeCap *big.Int
+
+	// Gas tip cap to use for the EIP-1559 transaction.
+	GasTipCap *big.Int
+
+	// Type of transaction.
+	Type TxType
 }
 
 // Receipt represents the results of a transaction.

--- a/pkg/chain/ethlike/chain.go
+++ b/pkg/chain/ethlike/chain.go
@@ -6,14 +6,6 @@ import (
 	"math/big"
 )
 
-// Hash represents the 32 byte Keccak256 hash of arbitrary data.
-type Hash [32]byte
-
-// TerminalString returns the hash as a console string.
-func (h Hash) TerminalString() string {
-	return fmt.Sprintf("%x…%x", h[:3], h[29:])
-}
-
 // Address represents the 20 byte address of an ETH-like account.
 type Address [20]byte
 
@@ -24,50 +16,12 @@ func (a Address) TerminalString() string {
 
 // Header represents a block header in the ETH-like blockchain.
 type Header struct {
-	Number  *big.Int
-	BaseFee *big.Int // Added by EIP-1559 and is ignored in legacy headers.
+	Number *big.Int
 }
 
 // Block represents an entire block in the ETH-like blockchain.
 type Block struct {
 	*Header
-}
-
-// TxType represents an ETH-like transaction type.
-type TxType int
-
-// Possible ETH-like transaction types.
-const (
-	// LegacyTxType represents a pre EIP-1559 legacy transaction.
-	LegacyTxType TxType = iota
-	// AccessListTxType represents a EIP-2930 access list transaction.
-	AccessListTxType
-	// DynamicFeeTxType represents a post EIP-1559 dynamic fee transaction.
-	DynamicFeeTxType
-)
-
-// Transaction represents an ETH-like chain transaction.
-type Transaction struct {
-	// Transaction hash.
-	Hash Hash
-
-	// Gas price to use for legacy (pre EIP-1559) transaction.
-	GasPrice *big.Int
-
-	// Gas fee cap to use for the EIP-1559 transaction.
-	GasFeeCap *big.Int
-
-	// Gas tip cap to use for the EIP-1559 transaction.
-	GasTipCap *big.Int
-
-	// Type of transaction.
-	Type TxType
-}
-
-// Receipt represents the results of a transaction.
-type Receipt struct {
-	Status      uint64
-	BlockNumber *big.Int
 }
 
 // Subscription represents an event subscription where events are delivered
@@ -97,14 +51,6 @@ type ChainReader interface {
 	) (Subscription, error)
 }
 
-// TransactionReader provides access to past transactions and their receipts.
-type TransactionReader interface {
-	// TransactionReceipt returns the receipt of a mined transaction.
-	// Note that the transaction may not be included in the current canonical
-	// chain even if a receipt exists.
-	TransactionReceipt(ctx context.Context, txHash Hash) (*Receipt, error)
-}
-
 // ContractTransactor defines the methods needed to allow operating with
 // contract on a write only basis.
 type ContractTransactor interface {
@@ -116,6 +62,5 @@ type ContractTransactor interface {
 // Chain represents an ETH-like chain handle.
 type Chain interface {
 	ChainReader
-	TransactionReader
 	ContractTransactor
 }

--- a/pkg/chain/ethlike/chain.go
+++ b/pkg/chain/ethlike/chain.go
@@ -24,7 +24,8 @@ func (a Address) TerminalString() string {
 
 // Header represents a block header in the ETH-like blockchain.
 type Header struct {
-	Number *big.Int
+	Number  *big.Int
+	BaseFee *big.Int // Added by EIP-1559 and is ignored in legacy headers.
 }
 
 // Block represents an entire block in the ETH-like blockchain.

--- a/pkg/chain/ethlike/mining_waiter.go
+++ b/pkg/chain/ethlike/mining_waiter.go
@@ -306,6 +306,20 @@ func (mw *MiningWaiter) forceMiningDynamicFeeTx(
 		// with the maximum.
 		if newGasFeeCap.Cmp(mw.maxGasFeeCap) > 0 {
 			newGasFeeCap = mw.maxGasFeeCap
+
+			// Check if the threshold condition is fulfilled once again.
+			// If the maximum allowed gas fee cap is below the threshold,
+			// there is no sense to submit the transaction as it won't
+			// be accepted by the miners.
+			if newGasFeeCap.Cmp(requiredGasFeeCapThreshold) < 0 {
+				logger.Infof(
+					"could not fulfill required gas fee cap threshold as " +
+						"the maximum gas fee cap value defined in config " +
+						"has been reached; " +
+						"stopping resubmissions",
+				)
+				return
+			}
 		}
 
 		// Transaction not yet mined and we are still under the maximum allowed

--- a/pkg/chain/ethlike/mining_waiter.go
+++ b/pkg/chain/ethlike/mining_waiter.go
@@ -2,6 +2,7 @@ package ethlike
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 )
@@ -75,10 +76,17 @@ func (mw *MiningWaiter) waitMined(
 	}
 }
 
+// ResubmitParams determines price parameters for transaction resubmission.
+type ResubmitParams struct {
+	GasPrice  *big.Int
+	GasFeeCap *big.Int
+	GasTipCap *big.Int
+}
+
 // ResubmitTransactionFn implements the code for resubmitting the transaction
 // after mining waiter performs the action. It should guarantee the same nonce
 // is used for transaction resubmission.
-type ResubmitTransactionFn func(gasPrice *big.Int) (*Transaction, error)
+type ResubmitTransactionFn func(params *ResubmitParams) (*Transaction, error)
 
 // ForceMining blocks until the transaction is mined and performs an appropriate
 // action to increase mining probability in the intervals defined by MiningWaiter
@@ -106,6 +114,11 @@ func (mw *MiningWaiter) forceMiningLegacyTx(
 	originalTransaction *Transaction,
 	resubmitFn ResubmitTransactionFn,
 ) {
+	logger.Infof(
+		"starting mining waiter for legacy transaction: [%v]",
+		originalTransaction.Hash.TerminalString(),
+	)
+
 	// For legacy transactions, the `maxGasFeeCap` is considered to be the same
 	// as `maxGasPrice`. This is because both parameters means the same:
 	// the maximum possible price per gas.
@@ -173,7 +186,11 @@ func (mw *MiningWaiter) forceMiningLegacyTx(
 			transaction.Hash.TerminalString(),
 			gasPrice,
 		)
-		transaction, err = resubmitFn(gasPrice)
+		transaction, err = resubmitFn(
+			&ResubmitParams{
+				GasPrice: gasPrice,
+			},
+		)
 		if err != nil {
 			logger.Warningf(
 				"could not resubmit TX with a higher gas price: [%v]",
@@ -188,5 +205,149 @@ func (mw *MiningWaiter) forceMiningDynamicFeeTx(
 	originalTransaction *Transaction,
 	resubmitFn ResubmitTransactionFn,
 ) {
-	// TODO: implementation
+	logger.Infof(
+		"starting mining waiter for dynamic fee transaction: [%v]",
+		originalTransaction.Hash.TerminalString(),
+	)
+
+	// If the original transaction's gas fee cap was higher or equal the max
+	// allowed we do nothing; we need to wait for it to be mined.
+	if originalTransaction.GasFeeCap.Cmp(mw.maxGasFeeCap) >= 0 {
+		logger.Infof(
+			"original transaction gas fee cap is higher than the max allowed; " +
+				"skipping resubmissions",
+		)
+		return
+	}
+
+	transaction := originalTransaction
+	for {
+		receipt, err := mw.waitMined(mw.checkInterval, transaction)
+		if err != nil {
+			logger.Infof(
+				"transaction [%v] not yet mined: [%v]",
+				transaction.Hash.TerminalString(),
+				err,
+			)
+		}
+
+		// Transaction mined, we are good.
+		if receipt != nil {
+			logger.Infof(
+				"transaction [%v] mined with status [%v] at block [%v]",
+				transaction.Hash.TerminalString(),
+				receipt.Status,
+				receipt.BlockNumber,
+			)
+			return
+		}
+
+		// Transaction not yet mined, if the previous gas fee cap was the
+		// maximum one, we no longer resubmit.
+		oldGasFeeCap := transaction.GasFeeCap
+		if oldGasFeeCap.Cmp(mw.maxGasFeeCap) == 0 {
+			logger.Infof(
+				"reached the maximum allowed gas fee cap; " +
+					"stopping resubmissions",
+			)
+			return
+		}
+
+		// Increase the gas tip cap by 20%. A minimum increase by 10% comparing
+		// to the previous value is required for transaction replacement to be
+		// accepted by miners as mentioned in:
+		// https://github.com/ethereum/go-ethereum/pull/22898/files#r636583352.
+		// We increase it even more than the required level to greatly increase
+		// the transaction's chance for being picked up by miners.
+		oldGasTipCap := transaction.GasTipCap
+		newGasTipCap := new(big.Int).Add(
+			oldGasTipCap,
+			new(big.Int).Div(oldGasTipCap, big.NewInt(5)),
+		)
+
+		// Fetch latest base fee from the chain. It's needed to compute the
+		// new value of gas fee cap.
+		latestBaseFee, err := mw.latestBaseFee()
+		if err != nil {
+			logger.Errorf("could not get latest base fee: [%v]", err)
+			return
+		}
+
+		// Compute new value of gas fee cap using the latest base fee
+		// and new gas tip cap. The `gasFeeCap = 2 * baseFee + gasTipCap`
+		// equation originates from `go-ethereum` which estimates this
+		// parameter in that way.
+		// See: https://github.com/ethereum/go-ethereum/pull/23038.
+		// Having the `baseFee` taken twice means the `gasFeeCap` should
+		// be resilient for six consecutive increases of the `baseFee`.
+		// This is because `baseFee` can be increased by 12.5% at maximum
+		// within a single increase.
+		newGasFeeCap := new(big.Int).Add(
+			new(big.Int).Mul(latestBaseFee, big.NewInt(2)),
+			newGasTipCap,
+		)
+
+		// The new gas fee cap value needs to be at least 10% bigger
+		// than the old value. Otherwise, the transaction replacement
+		// won't be accepted by miners as mentioned in:
+		// https://github.com/ethereum/go-ethereum/pull/22898/files#r636583352.
+		// If that's the case (e.g. the `baseFee` dramatically decreased since
+		// the previous transaction) we need to set the new gas fee cap value
+		// to the minimum value acceptable by miners.
+		requiredGasFeeCapThreshold := new(big.Int).Add(
+			oldGasFeeCap,
+			new(big.Int).Div(oldGasFeeCap, big.NewInt(10)),
+		)
+		if newGasFeeCap.Cmp(requiredGasFeeCapThreshold) < 0 {
+			newGasFeeCap = requiredGasFeeCapThreshold
+		}
+
+		// If we reached the maximum allowed gas fee cap, submit one more time
+		// with the maximum.
+		if newGasFeeCap.Cmp(mw.maxGasFeeCap) > 0 {
+			newGasFeeCap = mw.maxGasFeeCap
+		}
+
+		// Transaction not yet mined and we are still under the maximum allowed
+		// gas fee cap; resubmitting transaction with gas fee and tip parameters
+		// evaluated earlier.
+		logger.Infof(
+			"resubmitting previous transaction [%v] "+
+				"with a higher gas fee cap [%v] and tip cap [%v]",
+			transaction.Hash.TerminalString(),
+			newGasFeeCap,
+			newGasTipCap,
+		)
+		transaction, err = resubmitFn(
+			&ResubmitParams{
+				GasFeeCap: newGasFeeCap,
+				GasTipCap: newGasTipCap,
+			},
+		)
+		if err != nil {
+			logger.Warningf(
+				"could not resubmit TX with a higher "+
+					"gas fee cap and tip cap: [%v]",
+				err,
+			)
+			return
+		}
+	}
+}
+
+func (mw *MiningWaiter) latestBaseFee() (*big.Int, error) {
+	latestBlock, err := mw.chain.BlockByNumber(
+		context.Background(),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not get latest block: [%v]", err)
+	}
+
+	baseFee := latestBlock.BaseFee
+	if baseFee == nil {
+		return nil, fmt.Errorf("not an EIP-1559 block")
+	}
+
+	return baseFee, nil
 }

--- a/pkg/chain/ethlike/mining_waiter.go
+++ b/pkg/chain/ethlike/mining_waiter.go
@@ -270,7 +270,7 @@ func (mw *MiningWaiter) forceMiningDynamicFeeTx(
 		latestBaseFee, err := mw.latestBaseFee()
 		if err != nil {
 			logger.Errorf("could not get latest base fee: [%v]", err)
-			return
+			continue
 		}
 
 		// Compute new value of gas fee cap using the latest base fee

--- a/pkg/chain/ethlike/mining_waiter.go
+++ b/pkg/chain/ethlike/mining_waiter.go
@@ -262,7 +262,7 @@ func (mw *MiningWaiter) forceMiningDynamicFeeTx(
 		oldGasTipCap := transaction.GasTipCap
 		newGasTipCap := new(big.Int).Add(
 			oldGasTipCap,
-			new(big.Int).Div(oldGasTipCap, big.NewInt(5)),
+			new(big.Int).Div(oldGasTipCap, big.NewInt(5)), // + 20%
 		)
 
 		// Fetch latest base fee from the chain. It's needed to compute the

--- a/pkg/chain/ethlike/mining_waiter_test.go
+++ b/pkg/chain/ethlike/mining_waiter_test.go
@@ -10,18 +10,18 @@ import (
 
 const checkInterval = 100 * time.Millisecond
 
-var maxGasPrice = big.NewInt(45000000000) // 45 Gwei
+var maxGasFeeCap = big.NewInt(45000000000) // 45 Gwei
 
-func TestForceMining_Legacy_FirstMined(t *testing.T) {
+func TestForceMining_Legacy_NoResubmission(t *testing.T) {
 	originalTransaction := createLegacyTransaction(big.NewInt(20000000000)) // 20 Gwei
 
 	chain := newMockChain()
 
-	var resubmissionGasPrices []*big.Int
+	var resubmissionParams []*ResubmitParams
 
-	resubmitFn := func(gasPrice *big.Int) (*Transaction, error) {
-		resubmissionGasPrices = append(resubmissionGasPrices, gasPrice)
-		return createLegacyTransaction(gasPrice), nil
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		return createLegacyTransaction(params.GasPrice), nil
 	}
 
 	// receipt is already there
@@ -30,46 +30,63 @@ func TestForceMining_Legacy_FirstMined(t *testing.T) {
 	waiter := NewMiningWaiter(
 		chain,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 	waiter.ForceMining(
 		originalTransaction,
 		resubmitFn,
 	)
 
-	resubmissionCount := len(resubmissionGasPrices)
+	resubmissionCount := len(resubmissionParams)
 	if resubmissionCount != 0 {
 		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
 	}
 }
 
-func TestForceMining_Legacy_SecondMined(t *testing.T) {
+func TestForceMining_Legacy_OneResubmission(t *testing.T) {
 	originalTransaction := createLegacyTransaction(big.NewInt(20000000000)) // 20 Gwei
 
 	chain := newMockChain()
 
-	var resubmissionGasPrices []*big.Int
+	var resubmissionParams []*ResubmitParams
 
-	resubmitFn := func(gasPrice *big.Int) (*Transaction, error) {
-		resubmissionGasPrices = append(resubmissionGasPrices, gasPrice)
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
 		// first resubmission succeeded
 		chain.receipt = &Receipt{}
-		return createLegacyTransaction(gasPrice), nil
+		return createLegacyTransaction(params.GasPrice), nil
 	}
 
 	waiter := NewMiningWaiter(
 		chain,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 	waiter.ForceMining(
 		originalTransaction,
 		resubmitFn,
 	)
 
-	resubmissionCount := len(resubmissionGasPrices)
+	resubmissionCount := len(resubmissionParams)
 	if resubmissionCount != 1 {
 		t.Fatalf("expected one resubmission; has: [%v]", resubmissionCount)
+	}
+
+	resubmission := resubmissionParams[0]
+
+	if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
+		t.Fatalf("gas fee and tip cap should be nil")
+	}
+
+	expectedGasPrice := big.NewInt(24000000000)
+	if resubmission.GasPrice.Cmp(expectedGasPrice) != 0 {
+		t.Fatalf(
+			"unexpected gas price value\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedGasPrice,
+			resubmission.GasPrice,
+		)
 	}
 }
 
@@ -78,7 +95,7 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 
 	chain := newMockChain()
 
-	var resubmissionGasPrices []*big.Int
+	var resubmissionParams []*ResubmitParams
 
 	expectedAttempts := 3
 	expectedResubmissionGasPrices := []*big.Int{
@@ -88,27 +105,27 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 	}
 
 	attemptsSoFar := 1
-	resubmitFn := func(gasPrice *big.Int) (*Transaction, error) {
-		resubmissionGasPrices = append(resubmissionGasPrices, gasPrice)
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
 		if attemptsSoFar == expectedAttempts {
 			chain.receipt = &Receipt{}
 		} else {
 			attemptsSoFar++
 		}
-		return createLegacyTransaction(gasPrice), nil
+		return createLegacyTransaction(params.GasPrice), nil
 	}
 
 	waiter := NewMiningWaiter(
 		chain,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 	waiter.ForceMining(
 		originalTransaction,
 		resubmitFn,
 	)
 
-	resubmissionCount := len(resubmissionGasPrices)
+	resubmissionCount := len(resubmissionParams)
 	if resubmissionCount != expectedAttempts {
 		t.Fatalf(
 			"expected [%v] resubmission; has: [%v]",
@@ -117,12 +134,19 @@ func TestForceMining_Legacy_MultipleAttempts(t *testing.T) {
 		)
 	}
 
-	for resubmission, price := range resubmissionGasPrices {
-		if price.Cmp(expectedResubmissionGasPrices[resubmission]) != 0 {
+	for index, resubmission := range resubmissionParams {
+		if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
+			t.Fatalf("resubmission [%v] gas fee and tip cap should be nil", index)
+		}
+
+		price := resubmission.GasPrice
+		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {
 			t.Fatalf(
-				"unexpected [%v] resubmission gas price\nexpected: [%v]\nactual:   [%v]",
+				"unexpected resubmission [%v] gas price\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
 				resubmission,
-				expectedResubmissionGasPrices[resubmission],
+				expectedResubmissionGasPrices[index],
 				price,
 			)
 		}
@@ -134,7 +158,7 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 
 	chain := newMockChain()
 
-	var resubmissionGasPrices []*big.Int
+	var resubmissionParams []*ResubmitParams
 
 	expectedAttempts := 5
 	expectedResubmissionGasPrices := []*big.Int{
@@ -145,23 +169,23 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 		big.NewInt(45000000000), // max allowed
 	}
 
-	resubmitFn := func(gasPrice *big.Int) (*Transaction, error) {
-		resubmissionGasPrices = append(resubmissionGasPrices, gasPrice)
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
 		// not setting mockBackend.receipt, mining takes a very long time
-		return createLegacyTransaction(gasPrice), nil
+		return createLegacyTransaction(params.GasPrice), nil
 	}
 
 	waiter := NewMiningWaiter(
 		chain,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 	waiter.ForceMining(
 		originalTransaction,
 		resubmitFn,
 	)
 
-	resubmissionCount := len(resubmissionGasPrices)
+	resubmissionCount := len(resubmissionParams)
 	if resubmissionCount != expectedAttempts {
 		t.Fatalf(
 			"expected [%v] resubmission; has: [%v]",
@@ -170,12 +194,19 @@ func TestForceMining_Legacy_MaxAllowedPriceReached(t *testing.T) {
 		)
 	}
 
-	for resubmission, price := range resubmissionGasPrices {
-		if price.Cmp(expectedResubmissionGasPrices[resubmission]) != 0 {
+	for index, resubmission := range resubmissionParams {
+		if resubmission.GasFeeCap != nil || resubmission.GasTipCap != nil {
+			t.Fatalf("resubmission [%v] gas fee and tip cap should be nil", index)
+		}
+
+		price := resubmission.GasPrice
+		if price.Cmp(expectedResubmissionGasPrices[index]) != 0 {
 			t.Fatalf(
-				"unexpected [%v] resubmission gas price\nexpected: [%v]\nactual:   [%v]",
+				"unexpected resubmission [%v] gas price\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
 				resubmission,
-				expectedResubmissionGasPrices[resubmission],
+				expectedResubmissionGasPrices[index],
 				price,
 			)
 		}
@@ -189,25 +220,508 @@ func TestForceMining_Legacy_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
 
 	chain := newMockChain()
 
-	var resubmissionGasPrices []*big.Int
+	var resubmissionParams []*ResubmitParams
 
-	resubmitFn := func(gasPrice *big.Int) (*Transaction, error) {
-		resubmissionGasPrices = append(resubmissionGasPrices, gasPrice)
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
 		// not setting mockBackend.receipt, mining takes a very long time
-		return createLegacyTransaction(gasPrice), nil
+		return createLegacyTransaction(params.GasPrice), nil
 	}
 
 	waiter := NewMiningWaiter(
 		chain,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 	waiter.ForceMining(
 		originalTransaction,
 		resubmitFn,
 	)
 
-	resubmissionCount := len(resubmissionGasPrices)
+	resubmissionCount := len(resubmissionParams)
+	if resubmissionCount != 0 {
+		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
+	}
+}
+
+func TestForceMining_DynamicFee_NoResubmission(t *testing.T) {
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(24000000000) // 24 Gwei (2 * baseFee + gasTipCap)
+
+	originalTransaction := createDynamicFeeTransaction(
+		originalGasFeeCap,
+		originalGasTipCap,
+	)
+
+	chain := newMockChain()
+
+	// Base fee remains unchanged.
+	chain.blocks = []*Block{
+		{&Header{big.NewInt(1), originalBaseFee}},
+	}
+
+	var resubmissionParams []*ResubmitParams
+
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		return createDynamicFeeTransaction(
+			params.GasFeeCap,
+			params.GasTipCap,
+		), nil
+	}
+
+	// Receipt is already there.
+	chain.receipt = &Receipt{}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissionParams)
+	if resubmissionCount != 0 {
+		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
+	}
+}
+
+func TestForceMining_DynamicFee_OneResubmission(t *testing.T) {
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(24000000000) // 24 Gwei (2 * baseFee + gasTipCap)
+
+	var tests = map[string]struct {
+		nextBaseFee       *big.Int
+		expectedGasFeeCap *big.Int
+		expectedGasTipCap *big.Int
+	}{
+		"base fee decreased": {
+			// Base fee decreased to 5 Gwei.
+			nextBaseFee: big.NewInt(5000000000),
+			// Gas fee cap should be computed as: 2 * 5 Gwei + 4.8 Gwei = 14.8 Gwei.
+			// However, this value doesn't fulfill the required fee bump threshold.
+			// In result, the new gas fee value should be bumped up by 10% to
+			// satisfy the condition: 24 Gwei * 1.1 = 26.4 Gwei
+			expectedGasFeeCap: big.NewInt(26400000000),
+			// Gas tip cap should be bumped up by 20%: 4 Gwei * 1.2 = 4.8 Gwei
+			expectedGasTipCap: big.NewInt(4800000000),
+		},
+		"base fee unchanged": {
+			// Base fee remains 10 Gwei.
+			nextBaseFee: originalBaseFee,
+			// Gas fee cap should be computed as: 2 * 10 Gwei + 4.8 Gwei = 24.8 Gwei.
+			// However, this value doesn't fulfill the required fee bump threshold.
+			// In result, the new gas fee value should be bumped up by 10% to
+			// satisfy the condition: 24 Gwei * 1.1 = 26.4 Gwei
+			expectedGasFeeCap: big.NewInt(26400000000),
+			// Gas tip cap should be bumped up by 20%: 4 Gwei * 1.2 = 4.8 Gwei
+			expectedGasTipCap: big.NewInt(4800000000),
+		},
+		"base fee increased": {
+			// Base fee increased to 20 Gwei.
+			nextBaseFee: big.NewInt(20000000000),
+			// Gas fee cap should be computed as: 2 * 20 Gwei + 4.8 Gwei = 44.8 Gwei.
+			expectedGasFeeCap: big.NewInt(44800000000),
+			// Gas tip cap should be bumped up by 20%: 4 Gwei * 1.2 = 4.8 Gwei
+			expectedGasTipCap: big.NewInt(4800000000),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			originalTransaction := createDynamicFeeTransaction(
+				originalGasFeeCap,
+				originalGasTipCap,
+			)
+
+			chain := newMockChain()
+
+			chain.blocks = []*Block{
+				{&Header{big.NewInt(1), test.nextBaseFee}},
+			}
+
+			var resubmissionParams []*ResubmitParams
+
+			resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+				resubmissionParams = append(resubmissionParams, params)
+				// First resubmission succeeded.
+				chain.receipt = &Receipt{}
+				return createDynamicFeeTransaction(
+					params.GasFeeCap,
+					params.GasTipCap,
+				), nil
+			}
+
+			waiter := NewMiningWaiter(
+				chain,
+				checkInterval,
+				maxGasFeeCap,
+			)
+			waiter.ForceMining(
+				originalTransaction,
+				resubmitFn,
+			)
+
+			resubmissionCount := len(resubmissionParams)
+			if resubmissionCount != 1 {
+				t.Fatalf(
+					"expected one resubmission; has: [%v]",
+					resubmissionCount,
+				)
+			}
+
+			resubmission := resubmissionParams[0]
+
+			if resubmission.GasPrice != nil {
+				t.Fatalf("gas price should be nil")
+			}
+
+			if resubmission.GasFeeCap.Cmp(test.expectedGasFeeCap) != 0 {
+				t.Fatalf(
+					"unexpected gas fee cap value\n"+
+						"expected: [%v]\n"+
+						"actual:   [%v]",
+					test.expectedGasFeeCap,
+					resubmission.GasFeeCap,
+				)
+			}
+
+			if resubmission.GasTipCap.Cmp(test.expectedGasTipCap) != 0 {
+				t.Fatalf(
+					"unexpected gas tip cap value\n"+
+						"expected: [%v]\n"+
+						"actual:   [%v]",
+					test.expectedGasTipCap,
+					resubmission.GasTipCap,
+				)
+			}
+		})
+	}
+}
+
+func TestForceMining_DynamicFee_MultipleAttemps(t *testing.T) {
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(24000000000) // 24 Gwei (2 * baseFee + gasTipCap)
+
+	originalTransaction := createDynamicFeeTransaction(
+		originalGasFeeCap,
+		originalGasTipCap,
+	)
+
+	chain := newMockChain()
+
+	// Base fee remains unchanged.
+	chain.blocks = []*Block{
+		{&Header{big.NewInt(1), originalBaseFee}},
+	}
+
+	var resubmissionParams []*ResubmitParams
+
+	expectedAttempts := 3
+	expectedResubmissionParams := []*ResubmitParams{
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(26400000000), big.NewInt(4800000000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(29040000000), big.NewInt(5760000000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(31944000000), big.NewInt(6912000000)},
+	}
+
+	attemptsSoFar := 1
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		if attemptsSoFar == expectedAttempts {
+			chain.receipt = &Receipt{}
+		} else {
+			attemptsSoFar++
+		}
+		return createDynamicFeeTransaction(
+			params.GasFeeCap,
+			params.GasTipCap,
+		), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissionParams)
+	if resubmissionCount != expectedAttempts {
+		t.Fatalf(
+			"expected [%v] resubmission; has: [%v]",
+			expectedAttempts,
+			resubmissionCount,
+		)
+	}
+
+	for index, resubmission := range resubmissionParams {
+		if resubmission.GasPrice != nil {
+			t.Fatalf("resubmission [%v] gas price should be nil", index)
+		}
+
+		expectedGasFeeCap := expectedResubmissionParams[index].GasFeeCap
+		if resubmission.GasFeeCap.Cmp(expectedGasFeeCap) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v] gas fee cap value\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedGasFeeCap,
+				resubmission.GasFeeCap,
+			)
+		}
+
+		expectedGasTipCap := expectedResubmissionParams[index].GasTipCap
+		if resubmission.GasTipCap.Cmp(expectedGasTipCap) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v]  gas tip cap value\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedGasTipCap,
+				resubmission.GasTipCap,
+			)
+		}
+	}
+}
+
+func TestForceMining_DynamicFee_MaxAllowedPriceReached(t *testing.T) {
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(24000000000) // 24 Gwei (2 * baseFee + gasTipCap)
+
+	originalTransaction := createDynamicFeeTransaction(
+		originalGasFeeCap,
+		originalGasTipCap,
+	)
+
+	chain := newMockChain()
+
+	chain.blocks = []*Block{
+		{
+			&Header{
+				big.NewInt(1),
+				// Massive increase of base fee to 30 Gwei. This is needed
+				// to exceed the maximum gas fee cap value.
+				new(big.Int).Mul(originalBaseFee, big.NewInt(3)),
+			},
+		},
+	}
+
+	var resubmissionParams []*ResubmitParams
+
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		// Not setting mockBackend.receipt, mining takes a very long time.
+		return createDynamicFeeTransaction(
+			params.GasFeeCap,
+			params.GasTipCap,
+		), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissionParams)
+	if resubmissionCount != 1 {
+		t.Fatalf(
+			"expected one resubmission; has: [%v]",
+			resubmissionCount,
+		)
+	}
+
+	resubmission := resubmissionParams[0]
+
+	if resubmission.GasPrice != nil {
+		t.Fatalf("gas price should be nil")
+	}
+
+	// The new gas fee value should be computed as usual:
+	// 2 * 30 Gwei + 4.8 gwei = 64.8 Gwei. However, max gas fee cap value
+	// is 45 Gwei so this value should be used instead.
+	expectedGasFeeCap := big.NewInt(45000000000)
+	if resubmission.GasFeeCap.Cmp(expectedGasFeeCap) != 0 {
+		t.Fatalf(
+			"unexpected gas fee cap value\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedGasFeeCap,
+			resubmission.GasFeeCap,
+		)
+	}
+
+	// Gas tip cap should be bumped up by 20%: 4 Gwei * 1.2 = 4.8 Gwei
+	expectedGasTipCap := big.NewInt(4800000000)
+	if resubmission.GasTipCap.Cmp(expectedGasTipCap) != 0 {
+		t.Fatalf(
+			"unexpected gas tip cap value\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedGasTipCap,
+			resubmission.GasTipCap,
+		)
+	}
+}
+
+func TestForceMining_DynamicFee_MaxAllowedPriceReachedButBelowThreshold(t *testing.T) {
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(24000000000) // 24 Gwei (2 * baseFee + gasTipCap)
+
+	originalTransaction := createDynamicFeeTransaction(
+		originalGasFeeCap,
+		originalGasTipCap,
+	)
+
+	chain := newMockChain()
+
+	// Base fee remains unchanged.
+	chain.blocks = []*Block{
+		{&Header{big.NewInt(1), originalBaseFee}},
+	}
+
+	var resubmissionParams []*ResubmitParams
+
+	expectedAttempts := 6
+	expectedResubmissionParams := []*ResubmitParams{
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(26400000000), big.NewInt(4800000000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(29040000000), big.NewInt(5760000000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(31944000000), big.NewInt(6912000000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(35138400000), big.NewInt(8294400000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(38652240000), big.NewInt(9953280000)},
+		// gasFeeCap +10%, gasTipCap +20%
+		{nil, big.NewInt(42517464000), big.NewInt(11943936000)},
+		// The last attempt would bump the gas fee cap up to 46769210400.
+		// However, this value exceeds the max gas fee cap which is 45000000000.
+		// On the other hand, the max gas fee cap is under the required fee bump
+		// threshold for this iteration so resubmission should not be performed
+		// at all.
+	}
+
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		// Not setting mockBackend.receipt, mining takes a very long time.
+		return createDynamicFeeTransaction(
+			params.GasFeeCap,
+			params.GasTipCap,
+		), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissionParams)
+	if resubmissionCount != expectedAttempts {
+		t.Fatalf(
+			"expected [%v] resubmission; has: [%v]",
+			expectedAttempts,
+			resubmissionCount,
+		)
+	}
+
+	for index, resubmission := range resubmissionParams {
+		if resubmission.GasPrice != nil {
+			t.Fatalf("resubmission [%v] gas price should be nil", index)
+		}
+
+		expectedGasFeeCap := expectedResubmissionParams[index].GasFeeCap
+		if resubmission.GasFeeCap.Cmp(expectedGasFeeCap) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v] gas fee cap value\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedGasFeeCap,
+				resubmission.GasFeeCap,
+			)
+		}
+
+		expectedGasTipCap := expectedResubmissionParams[index].GasTipCap
+		if resubmission.GasTipCap.Cmp(expectedGasTipCap) != 0 {
+			t.Fatalf(
+				"unexpected resubmission [%v]  gas tip cap value\n"+
+					"expected: [%v]\n"+
+					"actual:   [%v]",
+				index,
+				expectedGasTipCap,
+				resubmission.GasTipCap,
+			)
+		}
+	}
+}
+
+func TestForceMining_DynamicFee_OriginalPriceHigherThanMaxAllowed(t *testing.T) {
+	// Original transaction has gas fee cap set at 46 Gwei, the maximum allowed
+	// gas fee cap is 45 Gwei.
+	originalBaseFee := big.NewInt(10000000000)   // 10 Gwei
+	originalGasTipCap := big.NewInt(4000000000)  // 4 Gwei
+	originalGasFeeCap := big.NewInt(46000000000) // 46 Gwei
+
+	originalTransaction := createDynamicFeeTransaction(
+		originalGasFeeCap,
+		originalGasTipCap,
+	)
+
+	chain := newMockChain()
+
+	// Base fee remains unchanged.
+	chain.blocks = []*Block{
+		{&Header{big.NewInt(1), originalBaseFee}},
+	}
+
+	var resubmissionParams []*ResubmitParams
+
+	resubmitFn := func(params *ResubmitParams) (*Transaction, error) {
+		resubmissionParams = append(resubmissionParams, params)
+		// Not setting mockBackend.receipt, mining takes a very long time.
+		return createDynamicFeeTransaction(
+			params.GasFeeCap,
+			params.GasTipCap,
+		), nil
+	}
+
+	waiter := NewMiningWaiter(
+		chain,
+		checkInterval,
+		maxGasFeeCap,
+	)
+	waiter.ForceMining(
+		originalTransaction,
+		resubmitFn,
+	)
+
+	resubmissionCount := len(resubmissionParams)
 	if resubmissionCount != 0 {
 		t.Fatalf("expected no resubmissions; has: [%v]", resubmissionCount)
 	}
@@ -230,6 +744,25 @@ func createLegacyTransaction(gasPrice *big.Int) *Transaction {
 	}
 }
 
+func createDynamicFeeTransaction(gasFeeCap, gasTipCap *big.Int) *Transaction {
+	hashSlice, err := hex.DecodeString(
+		"121D387731bBbC988B312206c74F77D004D6B84b",
+	)
+	if err != nil {
+		return nil
+	}
+
+	var hash [32]byte
+	copy(hash[:], hashSlice)
+
+	return &Transaction{
+		Hash:      hash,
+		GasFeeCap: gasFeeCap,
+		GasTipCap: gasTipCap,
+		Type:      DynamicFeeTxType,
+	}
+}
+
 type mockChain struct {
 	*mockChainReader
 	*mockTransactionReader
@@ -238,19 +771,27 @@ type mockChain struct {
 
 func newMockChain() *mockChain {
 	return &mockChain{
-		mockChainReader:        &mockChainReader{},
+		mockChainReader: &mockChainReader{
+			blocks: make([]*Block, 0),
+		},
 		mockTransactionReader:  &mockTransactionReader{},
 		mockContractTransactor: &mockContractTransactor{},
 	}
 }
 
-type mockChainReader struct{}
+type mockChainReader struct {
+	blocks []*Block
+}
 
 func (mcr *mockChainReader) BlockByNumber(
 	ctx context.Context,
 	number *big.Int,
 ) (*Block, error) {
-	panic("implement me")
+	if number == nil {
+		return mcr.blocks[len(mcr.blocks)-1], nil
+	}
+
+	return mcr.blocks[number.Int64()], nil
 }
 
 func (mcr *mockChainReader) SubscribeNewHead(

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -4,9 +4,6 @@ package cmd
 
 import (
 	"fmt"
-	"math/big"
-	"time"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/cmd/flag"
 	"github.com/urfave/cli"
@@ -43,19 +40,6 @@ var (
 	// interaction. The value, if that flag is passed on the command line, is
 	// stored in this variable.
 	ValueFlagValue *flag.Uint256 = &flag.Uint256{}
-
-	// DefaultMiningCheckInterval is the default interval in which transaction
-	// mining status is checked. If the transaction is not mined within this
-	// time, the gas price is increased and transaction is resubmitted.
-	// This value can be overwritten in the configuration file.
-	DefaultMiningCheckInterval = 60 * time.Second
-
-	// DefaultMaxGasPrice specifies the default maximum gas price the client is
-	// willing to pay for the transaction to be mined. The offered transaction
-	// gas price can not be higher than the max gas price value. If the maximum
-	// allowed gas price is reached, no further resubmission attempts are
-	// performed. This value can be overwritten in the configuration file.
-	DefaultMaxGasPrice = big.NewInt(500000000000) // 500 Gwei
 )
 
 // AvailableCommands is the exported list of generated commands that can be

--- a/tools/generators/ethlike/command.go.tmpl
+++ b/tools/generators/ethlike/command.go.tmpl
@@ -223,20 +223,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         )
     }
 
-	checkInterval := cmd.DefaultMiningCheckInterval
-	maxGasFeeCap := cmd.DefaultMaxGasFeeCap
-	if config.MiningCheckInterval != 0 {
-		checkInterval = time.Duration(config.MiningCheckInterval) * time.Second
-	}
-	if config.MaxGasFeeCap != nil {
-		maxGasFeeCap = config.MaxGasFeeCap.Int
-	}
-
-	miningWaiter := chainutil.NewMiningWaiter(
-		client,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	miningWaiter := chainutil.NewMiningWaiter(client, config)
 
 	blockCounter, err := chainutil.NewBlockCounter(client)
 	if err != nil {

--- a/tools/generators/ethlike/command.go.tmpl
+++ b/tools/generators/ethlike/command.go.tmpl
@@ -224,18 +224,18 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
     }
 
 	checkInterval := cmd.DefaultMiningCheckInterval
-	maxGasPrice := cmd.DefaultMaxGasPrice
+	maxGasFeeCap := cmd.DefaultMaxGasFeeCap
 	if config.MiningCheckInterval != 0 {
 		checkInterval = time.Duration(config.MiningCheckInterval) * time.Second
 	}
-	if config.MaxGasPrice != nil {
-		maxGasPrice = config.MaxGasPrice.Int
+	if config.MaxGasFeeCap != nil {
+		maxGasFeeCap = config.MaxGasFeeCap.Int
 	}
 
 	miningWaiter := chainutil.NewMiningWaiter(
 		client,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 
 	blockCounter, err := chainutil.NewBlockCounter(client)

--- a/tools/generators/ethlike/command_template_content.go
+++ b/tools/generators/ethlike/command_template_content.go
@@ -227,18 +227,18 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
     }
 
 	checkInterval := cmd.DefaultMiningCheckInterval
-	maxGasPrice := cmd.DefaultMaxGasPrice
+	maxGasFeeCap := cmd.DefaultMaxGasFeeCap
 	if config.MiningCheckInterval != 0 {
 		checkInterval = time.Duration(config.MiningCheckInterval) * time.Second
 	}
-	if config.MaxGasPrice != nil {
-		maxGasPrice = config.MaxGasPrice.Int
+	if config.MaxGasFeeCap != nil {
+		maxGasFeeCap = config.MaxGasFeeCap.Int
 	}
 
 	miningWaiter := chainutil.NewMiningWaiter(
 		client,
 		checkInterval,
-		maxGasPrice,
+		maxGasFeeCap,
 	)
 
 	blockCounter, err := chainutil.NewBlockCounter(client)

--- a/tools/generators/ethlike/command_template_content.go
+++ b/tools/generators/ethlike/command_template_content.go
@@ -226,20 +226,7 @@ func initialize{{.Class}}(c *cli.Context) (*contract.{{.Class}}, error) {
         )
     }
 
-	checkInterval := cmd.DefaultMiningCheckInterval
-	maxGasFeeCap := cmd.DefaultMaxGasFeeCap
-	if config.MiningCheckInterval != 0 {
-		checkInterval = time.Duration(config.MiningCheckInterval) * time.Second
-	}
-	if config.MaxGasFeeCap != nil {
-		maxGasFeeCap = config.MaxGasFeeCap.Int
-	}
-
-	miningWaiter := chainutil.NewMiningWaiter(
-		client,
-		checkInterval,
-		maxGasFeeCap,
-	)
+	miningWaiter := chainutil.NewMiningWaiter(client, config)
 
 	blockCounter, err := chainutil.NewBlockCounter(client)
 	if err != nil {

--- a/tools/generators/ethlike/contract.go.tmpl
+++ b/tools/generators/ethlike/contract.go.tmpl
@@ -37,7 +37,7 @@ type {{.Class}} struct {
 	transactorOptions  *bind.TransactOpts
 	errorResolver      *chainutil.ErrorResolver
 	nonceManager       *ethlike.NonceManager
-	miningWaiter       *ethlike.MiningWaiter
+	miningWaiter       *chainutil.MiningWaiter
 	blockCounter	   *ethlike.BlockCounter
 
 	transactionMutex *sync.Mutex
@@ -49,7 +49,7 @@ func New{{.Class}}(
     accountKey *keystore.Key,
     backend bind.ContractBackend,
     nonceManager *ethlike.NonceManager,
-    miningWaiter *ethlike.MiningWaiter,
+    miningWaiter *chainutil.MiningWaiter,
     blockCounter *ethlike.BlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {

--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -77,6 +77,16 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
+			// If original transactor options has a non-zero gas limit, that
+			// means the client code set it on their own. In that case, we
+			// should rewrite the gas limit from the original transaction
+			// for each resubmission. If the gas limit is not set by the client
+			// code, let the the submitter re-estimate the gas limit on each
+			// resubmission.
+			if transactorOptions.GasLimit != 0 {
+				newTransactorOptions.GasLimit = transaction.Gas()
+			}
+
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		        newTransactorOptions,
 		        {{$method.Params}}

--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -75,12 +75,17 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 
 	go {{$contract.ShortVar}}.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     ethlike.Hash(transaction.Hash()),
-			GasPrice: transaction.GasPrice(),
+			Hash:      ethlike.Hash(transaction.Hash()),
+			GasPrice:  transaction.GasPrice(),
+			GasFeeCap: transaction.GasFeeCap(),
+			GasTipCap: transaction.GasTipCap(),
+			Type:      ethlike.TxType(transaction.Type()),
 		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+		func(params *ethlike.ResubmitParams) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
+			transactorOptions.GasPrice = params.GasPrice
+			transactorOptions.GasFeeCap = params.GasFeeCap
+			transactorOptions.GasTipCap = params.GasTipCap
 
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		        transactorOptions,
@@ -107,8 +112,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     ethlike.Hash(transaction.Hash()),
-				GasPrice: transaction.GasPrice(),
+				Hash:      ethlike.Hash(transaction.Hash()),
+				GasPrice:  transaction.GasPrice(),
+				GasFeeCap: transaction.GasFeeCap(),
+				GasTipCap: transaction.GasTipCap(),
+				Type:      ethlike.TxType(transaction.Type()),
             }, nil
 		},
 	)

--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -74,21 +74,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	)
 
 	go {{$contract.ShortVar}}.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:      ethlike.Hash(transaction.Hash()),
-			GasPrice:  transaction.GasPrice(),
-			GasFeeCap: transaction.GasFeeCap(),
-			GasTipCap: transaction.GasTipCap(),
-			Type:      ethlike.TxType(transaction.Type()),
-		},
-		func(params *ethlike.ResubmitParams) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = params.GasPrice
-			transactorOptions.GasFeeCap = params.GasFeeCap
-			transactorOptions.GasTipCap = params.GasTipCap
-
+		transaction,
+		transactorOptions,
+		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
-		        transactorOptions,
+		        newTransactorOptions,
 		        {{$method.Params}}
 	        )
 	        if err != nil {
@@ -111,13 +101,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 				transaction.Nonce(),
 			)
 
-			return &ethlike.Transaction{
-				Hash:      ethlike.Hash(transaction.Hash()),
-				GasPrice:  transaction.GasPrice(),
-				GasFeeCap: transaction.GasFeeCap(),
-				GasTipCap: transaction.GasTipCap(),
-				Type:      ethlike.TxType(transaction.Type()),
-            }, nil
+			return transaction, nil
 		},
 	)
 

--- a/tools/generators/ethlike/contract_non_const_methods.go.tmpl
+++ b/tools/generators/ethlike/contract_non_const_methods.go.tmpl
@@ -84,7 +84,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			// code, let the the submitter re-estimate the gas limit on each
 			// resubmission.
 			if transactorOptions.GasLimit != 0 {
-				newTransactorOptions.GasLimit = transaction.Gas()
+				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -77,21 +77,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	)
 
 	go {{$contract.ShortVar}}.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:      ethlike.Hash(transaction.Hash()),
-			GasPrice:  transaction.GasPrice(),
-			GasFeeCap: transaction.GasFeeCap(),
-			GasTipCap: transaction.GasTipCap(),
-			Type:      ethlike.TxType(transaction.Type()),
-		},
-		func(params *ethlike.ResubmitParams) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = params.GasPrice
-			transactorOptions.GasFeeCap = params.GasFeeCap
-			transactorOptions.GasTipCap = params.GasTipCap
-
+		transaction,
+		transactorOptions,
+		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
-		        transactorOptions,
+		        newTransactorOptions,
 		        {{$method.Params}}
 	        )
 	        if err != nil {
@@ -114,13 +104,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 				transaction.Nonce(),
 			)
 
-			return &ethlike.Transaction{
-				Hash:      ethlike.Hash(transaction.Hash()),
-				GasPrice:  transaction.GasPrice(),
-				GasFeeCap: transaction.GasFeeCap(),
-				GasTipCap: transaction.GasTipCap(),
-				Type:      ethlike.TxType(transaction.Type()),
-            }, nil
+			return transaction, nil
 		},
 	)
 

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -87,7 +87,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			// code, let the the submitter re-estimate the gas limit on each
 			// resubmission.
 			if transactorOptions.GasLimit != 0 {
-				newTransactorOptions.GasLimit = transaction.Gas()
+				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -78,12 +78,17 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 
 	go {{$contract.ShortVar}}.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     ethlike.Hash(transaction.Hash()),
-			GasPrice: transaction.GasPrice(),
+			Hash:      ethlike.Hash(transaction.Hash()),
+			GasPrice:  transaction.GasPrice(),
+			GasFeeCap: transaction.GasFeeCap(),
+			GasTipCap: transaction.GasTipCap(),
+			Type:      ethlike.TxType(transaction.Type()),
 		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+		func(params *ethlike.ResubmitParams) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
+			transactorOptions.GasPrice = params.GasPrice
+			transactorOptions.GasFeeCap = params.GasFeeCap
+			transactorOptions.GasTipCap = params.GasTipCap
 
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		        transactorOptions,
@@ -110,8 +115,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     ethlike.Hash(transaction.Hash()),
-				GasPrice: transaction.GasPrice(),
+				Hash:      ethlike.Hash(transaction.Hash()),
+				GasPrice:  transaction.GasPrice(),
+				GasFeeCap: transaction.GasFeeCap(),
+				GasTipCap: transaction.GasTipCap(),
+				Type:      ethlike.TxType(transaction.Type()),
             }, nil
 		},
 	)

--- a/tools/generators/ethlike/contract_non_const_methods_template_content.go
+++ b/tools/generators/ethlike/contract_non_const_methods_template_content.go
@@ -80,6 +80,16 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
+			// If original transactor options has a non-zero gas limit, that
+			// means the client code set it on their own. In that case, we
+			// should rewrite the gas limit from the original transaction
+			// for each resubmission. If the gas limit is not set by the client
+			// code, let the the submitter re-estimate the gas limit on each
+			// resubmission.
+			if transactorOptions.GasLimit != 0 {
+				newTransactorOptions.GasLimit = transaction.Gas()
+			}
+
 			transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
 		        newTransactorOptions,
 		        {{$method.Params}}

--- a/tools/generators/ethlike/contract_template_content.go
+++ b/tools/generators/ethlike/contract_template_content.go
@@ -40,7 +40,7 @@ type {{.Class}} struct {
 	transactorOptions  *bind.TransactOpts
 	errorResolver      *chainutil.ErrorResolver
 	nonceManager       *ethlike.NonceManager
-	miningWaiter       *ethlike.MiningWaiter
+	miningWaiter       *chainutil.MiningWaiter
 	blockCounter	   *ethlike.BlockCounter
 
 	transactionMutex *sync.Mutex
@@ -52,7 +52,7 @@ func New{{.Class}}(
     accountKey *keystore.Key,
     backend bind.ContractBackend,
     nonceManager *ethlike.NonceManager,
-    miningWaiter *ethlike.MiningWaiter,
+    miningWaiter *chainutil.MiningWaiter,
     blockCounter *ethlike.BlockCounter,
     transactionMutex *sync.Mutex,
 ) (*{{.Class}}, error) {


### PR DESCRIPTION
This pull request adds support of EIP-1559 to the mining waiter. Specific changes include:
- Refactoring of the mining waiter structure and preserving current functionality for legacy Ethereum and Celo transactions
- Getting rid of the mining waiter from `ethlike` package. Now Ethereum and Celo have their own implementations and all differences lying in transaction internals are well encapsulated
- Update of contract bindings generator to capture changes in the mining waiter
- Unit tests and documentation
- Applying changes in client repositories