### PR TITLE
EIP-1559 Ethereum transaction options

### DIFF
--- a/pkg/chain/ethereum/ethutil/transaction_opts.go
+++ b/pkg/chain/ethereum/ethutil/transaction_opts.go
@@ -9,23 +9,32 @@ import (
 // TransactionOptions represents custom transaction options which can be used
 // while invoking contracts methods.
 type TransactionOptions struct {
-	// GasLimit specifies a gas limit to set on a transaction call; should be
-	// ignored if set to 0.
+	// GasLimit specifies a gas limit to set for a transaction; estimated if
+	// set to 0.
 	GasLimit uint64
-	// GasPrice specifies a gas price to set on a transaction call; should be
-	// ignored if set to nil.
-	GasPrice *big.Int
+
+	// GasFeeCap specifies gas fee cap for EIP-1559 transaction; estimated if
+	// set to nil.
+	GasFeeCap *big.Int
+
+	// GasTipCap specifies gas priority fee cap to use for EIP-1559 transaction;
+	// estimated if set to nil.
+	GasTipCap *big.Int
 }
 
 // Apply takes a bind.TransactOpts pointer and applies the options described in
-// TransactionOptions to it. Note that a GasLimit of 0 or a GasPrice of nil are
-// not applied to the passed options; these values indicate that the options
-// should remain unchanged.
+// TransactionOptions to it. Note that GasTipCap, GasFeeCap set to nil and
+// GasLimit set to 0 are not applied to the passed bind.TransactOpts; these
+// values indicate that the original values in bind.TransactOpts should remain
+// unchanged.
 func (to TransactionOptions) Apply(transactorOptions *bind.TransactOpts) {
 	if customGasLimit := to.GasLimit; customGasLimit != 0 {
 		transactorOptions.GasLimit = customGasLimit
 	}
-	if customGasPrice := to.GasPrice; customGasPrice != nil {
-		transactorOptions.GasPrice = customGasPrice
+	if customGasFeeCap := to.GasFeeCap; customGasFeeCap != nil {
+		transactorOptions.GasFeeCap = customGasFeeCap
+	}
+	if customGasTipCap := to.GasTipCap; customGasTipCap != nil {
+		transactorOptions.GasTipCap = customGasTipCap
 	}
 }


### PR DESCRIPTION
Ethereum mining waiter has been already updated to support dynamic fee
(EIP-1559) transactions but ethutil.TransactionOpts still exposed only
GasPrice option. Setting this option resulted in marking the outgoing
transaction as a legacy type transaction. Given that the client should
use dynamic fee transactions, GasPrice option has been replaced with
GasFeeCap and GasTipCap. This change is only for Ethereum. Celo still
supports GasPrice as EIP-1559 affects only Ethereum.