### PR TITLE
Return a specific error when contract address is not found

### DIFF
--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -1,7 +1,9 @@
 package ethereum
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 )
@@ -25,15 +27,16 @@ type Config struct {
 	BalanceAlertThreshold *Wei
 }
 
+// ErrAddressNotConfigured is an error that is returned when an address for the given
+// contract name was not found in the Config.
+var ErrAddressNotConfigured = errors.New("address not configured")
+
 // ContractAddress finds a given contract's address configuration and returns it
 // as Ethereum address.
 func (c *Config) ContractAddress(contractName string) (common.Address, error) {
 	addressString, exists := c.ContractAddresses[contractName]
 	if !exists {
-		return common.Address{}, fmt.Errorf(
-			"no address information for [%v] in configuration",
-			contractName,
-		)
+		return common.Address{}, ErrAddressNotConfigured
 	}
 
 	if !common.IsHexAddress(addressString) {

--- a/pkg/chain/ethereum/config_test.go
+++ b/pkg/chain/ethereum/config_test.go
@@ -49,7 +49,7 @@ func TestContractAddress(t *testing.T) {
 		"missing contract configuration": {
 			contractName:    "Peekaboo",
 			expectedAddress: common.Address{},
-			expectedError:   fmt.Errorf("address not configured"),
+			expectedError:   ErrAddressNotConfigured,
 		},
 	}
 	for testName, test := range tests {

--- a/pkg/chain/ethereum/config_test.go
+++ b/pkg/chain/ethereum/config_test.go
@@ -2,9 +2,10 @@ package ethereum
 
 import (
 	"fmt"
-	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"reflect"
 	"testing"
+
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -48,8 +49,7 @@ func TestContractAddress(t *testing.T) {
 		"missing contract configuration": {
 			contractName:    "Peekaboo",
 			expectedAddress: common.Address{},
-			expectedError: fmt.Errorf("no address information " +
-				"for [Peekaboo] in configuration"),
+			expectedError:   fmt.Errorf("address not configured"),
 		},
 	}
 	for testName, test := range tests {


### PR DESCRIPTION
We want to return a specific error when a contract address is not configured so the client can handle such scenario with an alternative path.