### PR TITLE
Expose SetContractAddress function

### DIFF
--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -93,3 +93,9 @@ func (c *Config) ContractAddress(contractName string) (common.Address, error) {
 	address := common.HexToAddress(addressString)
 	return address, nil
 }
+
+// SetContractAddress sets address for a contract in the contracts addresses
+// mapping.
+func (c *Config) SetContractAddress(contractName string, address string) {
+	c.ContractAddresses[strings.ToLower(contractName)] = address
+}


### PR DESCRIPTION
The function should be used to configure addresses in the
ContractAddresses mapping. We're storing the contracts at a specific key
(lowercased) and we want to be consistent about that in all getters and
setters.