### PR TITLE
Check if contract address is empty string and return error

### DIFF
--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -77,7 +77,7 @@ var ErrAddressNotConfigured = errors.New("address not configured")
 // as Ethereum address.
 func (c *Config) ContractAddress(contractName string) (common.Address, error) {
 	addressString, exists := c.ContractAddresses[strings.ToLower(contractName)]
-	if !exists {
+	if !exists || addressString == "" {
 		return common.Address{}, ErrAddressNotConfigured
 	}
 


### PR DESCRIPTION
The mapping could exist but the address could be an empty string. In
such scenario we should verify also `addressString == ""` and return an
ErrAddressNotConfigured error.