### PR TITLE
Configure Ethereum network as enum in the etherem config

### DIFF
--- a/pkg/chain/ethereum/config.go
+++ b/pkg/chain/ethereum/config.go
@@ -12,6 +12,8 @@ import (
 // Config is a struct that contains the configuration needed to connect to an
 // Ethereum node. This information will give access to an Ethereum network.
 type Config struct {
+	Network
+
 	Account `mapstructure:",squash"`
 
 	// Example: "ws://192.168.0.157:8546".

--- a/pkg/chain/ethereum/network.go
+++ b/pkg/chain/ethereum/network.go
@@ -1,0 +1,24 @@
+package ethereum
+
+// Network is a type used for ethereum networks enumeration.
+type Network int
+
+// Ethereum networks enumeration.
+const (
+	Unknown Network = iota
+	Mainnet
+	Goerli
+	Developer
+)
+
+func (n Network) String() string {
+	switch n {
+	case Mainnet:
+		return "mainnet"
+	case Goerli:
+		return "goerli"
+	case Developer:
+		return "developer"
+	}
+	return "unknown"
+}

--- a/pkg/chain/ethereum/network.go
+++ b/pkg/chain/ethereum/network.go
@@ -12,13 +12,5 @@ const (
 )
 
 func (n Network) String() string {
-	switch n {
-	case Mainnet:
-		return "mainnet"
-	case Goerli:
-		return "goerli"
-	case Developer:
-		return "developer"
-	}
-	return "unknown"
+	return []string{"unknown", "mainnet", "goerli", "developer"}[n]
 }

--- a/pkg/chain/ethereum/network_test.go
+++ b/pkg/chain/ethereum/network_test.go
@@ -1,0 +1,44 @@
+package ethereum
+
+import (
+	"testing"
+)
+
+func TestNetworkString(t *testing.T) {
+	var tests = map[string]struct {
+		network        Network
+		expectedString string
+	}{
+		"Unknown": {
+			network:        Unknown,
+			expectedString: "unknown",
+		},
+		"Mainnet": {
+			network:        Mainnet,
+			expectedString: "mainnet",
+		},
+		"Goerli": {
+			network:        Goerli,
+			expectedString: "goerli",
+		},
+		"Developer": {
+			network:        Developer,
+			expectedString: "developer",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+
+			result := test.network.String()
+
+			if result != test.expectedString {
+				t.Errorf(
+					"\nexpected: %s\nactual:   %s",
+					test.expectedString,
+					result,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We add Network enumeration of supported Ethereum Networks like Mainnet
and Goerli. We include a property specifing the network in the
ethereum.Config struct.