### PR TITLE
Define Chain ID for Ethereum Network

### DIFF
--- a/pkg/chain/ethereum/network.go
+++ b/pkg/chain/ethereum/network.go
@@ -14,3 +14,14 @@ const (
 func (n Network) String() string {
 	return []string{"unknown", "mainnet", "goerli", "developer"}[n]
 }
+
+// ChainID returns chain id associated with the network.
+func (n Network) ChainID() int64 {
+	switch n {
+	case Mainnet:
+		return 1
+	case Goerli:
+		return 5
+	}
+	return 0
+}


### PR DESCRIPTION
Each Ethereum network works with an associated Chain ID.
Here we expose a function that returns a chain id for the network.

The Chain ID will be used by the client for validation.

Depends on https://github.com/keep-network/keep-common/pull/99