### PR TITLE
Use actions running on `node16`

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -13,10 +13,10 @@ jobs:
   client-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.18"
 
@@ -36,7 +36,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: securego/gosec@master
         with:
           args: ./...
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lint Go
         uses: keep-network/golint-action@v1.0.2


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. They plan to migrate all actions to run on Node16 by Summer 2023. Some of the GH Marketplace actions that we've been using in our workflows were running on `node12`, but have already published new versions running on `node16`. We're updating those actions to the latest versions.

Read more on
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.