### PR TITLE
Add the status badge to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,7 @@
 = `keep-common`
 
+https://github.com/keep-network/keep-common/actions/workflows/client.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-common/Go/main?event=push&label=Go build[Go build status]]
+
 Common libraries and tools used across Keep repositories.
 
 == Directory structure


### PR DESCRIPTION
We're adding a badge to the README file which shows the status of the workflow building and testing the Go code in the `keep-common` repository. The displayed status is based the status of the most recently executed `Go` workflow triggered by the push to `main`.

Refs:
https://github.com/threshold-network/token-dashboard/pull/296
https://github.com/keep-network/coverage-pools/pull/218
https://github.com/keep-network/keep-core/pull/3398
https://github.com/keep-network/sortition-pools/pull/194
https://github.com/keep-network/tbtc-v2/pull/420