### PR TITLE
Require parent context in wrappers

### DIFF
--- a/pkg/chain/ethereum/balance_monitor.go
+++ b/pkg/chain/ethereum/balance_monitor.go
@@ -64,7 +64,7 @@ func (bm *BalanceMonitor) Observe(
 		defer ticker.Stop()
 
 		checkBalance := func() {
-			err := wrappers.DoWithDefaultRetry(retryTimeout, check)
+			err := wrappers.DoWithDefaultRetry(ctx, retryTimeout, check)
 			if err != nil {
 				logger.Errorf("balance monitor error: [%v]", err)
 			}

--- a/pkg/wrappers/wrappers.go
+++ b/pkg/wrappers/wrappers.go
@@ -12,12 +12,13 @@ import (
 // before nth retry of doFn. In case the calculated backoff is longer than
 // backoffMax, the backoffMax wait is applied.
 func DoWithRetry(
+	parentCtx context.Context,
 	backoffTime time.Duration,
 	backoffMax time.Duration,
 	timeout time.Duration,
 	doFn func(ctx context.Context) error,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
 	var err error
@@ -68,10 +69,12 @@ const (
 // backoff is longer than DefaultMaxBackoffTime, the DefaultMaxBackoffTime is
 // applied.
 func DoWithDefaultRetry(
+	parentCtx context.Context,
 	timeout time.Duration,
 	doFn func(ctx context.Context) error,
 ) error {
 	return DoWithRetry(
+		parentCtx,
 		DefaultDoBackoffTime,
 		DefaultDoMaxBackoffTime,
 		timeout,
@@ -89,12 +92,13 @@ func DoWithDefaultRetry(
 // used to confirm a chain state and not to try to enforce a successful
 // execution of some function.
 func ConfirmWithTimeout(
+	parentCtx context.Context,
 	backoffTime time.Duration,
 	backoffMax time.Duration,
 	timeout time.Duration,
 	confirmFn func(ctx context.Context) (bool, error),
 ) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
 	for {
@@ -144,10 +148,12 @@ const (
 // ConfirmWithTimeoutDefaultBackoff is intended to be used to confirm a chain
 // state and not to try to enforce a successful execution of some function.
 func ConfirmWithTimeoutDefaultBackoff(
+	parentCtx context.Context,
 	timeout time.Duration,
 	confirmFn func(ctx context.Context) (bool, error),
 ) (bool, error) {
 	return ConfirmWithTimeout(
+		parentCtx,
 		DefaultConfirmBackoffTime,
 		DefaultConfirmMaxBackoffTime,
 		timeout,

--- a/pkg/wrappers/wrappers_test.go
+++ b/pkg/wrappers/wrappers_test.go
@@ -24,7 +24,7 @@ func TestDoWithRetry(t *testing.T) {
 		return nil
 	}
 
-	err := DoWithRetry(backoffTime, backoffMax, timeout, doFn)
+	err := DoWithRetry(context.Background(), backoffTime, backoffMax, timeout, doFn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestDoWithRetryExceedTimeout(t *testing.T) {
 		return nil
 	}
 
-	err := DoWithRetry(backoffTime, backoffMax, timeout, doFn)
+	err := DoWithRetry(context.Background(), backoffTime, backoffMax, timeout, doFn)
 	if err == nil {
 		t.Fatal("expected a timeout error")
 	}
@@ -107,7 +107,7 @@ func TestConfirmWithTimeout(t *testing.T) {
 		return true, nil
 	}
 
-	ok, err := ConfirmWithTimeout(backoffTime, backoffMax, timeout, confirmFn)
+	ok, err := ConfirmWithTimeout(context.Background(), backoffTime, backoffMax, timeout, confirmFn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestConfirmWithTimeoutExceedTimeout(t *testing.T) {
 		return true, nil
 	}
 
-	ok, err := ConfirmWithTimeout(backoffTime, backoffMax, timeout, confirmFn)
+	ok, err := ConfirmWithTimeout(context.Background(), backoffTime, backoffMax, timeout, confirmFn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestConfirmWithTimeoutFailure(t *testing.T) {
 		return false, fmt.Errorf("untada")
 	}
 
-	ok, err := ConfirmWithTimeout(backoffTime, backoffMax, timeout, confirmFn)
+	ok, err := ConfirmWithTimeout(context.Background(), backoffTime, backoffMax, timeout, confirmFn)
 	if err == nil {
 		t.Fatal("expected an error")
 	}


### PR DESCRIPTION
Instead of using `context.Background()` context in the wrappers we require a parent context to be passed so the retries and waits are correctly aborted when the parent context is done.