### PR TITLE
Handle abi prefix for structs nested in slices

### DIFF
--- a/tools/generators/ethereum/command.go.tmpl
+++ b/tools/generators/ethereum/command.go.tmpl
@@ -216,8 +216,12 @@ func {{$contract.ShortVar}}{{$method.CapsName}}(c *cobra.Command, args []string)
 		{{- else -}}
 		cmd.PrintOutput("success")
 		{{- end }}
-	}
 
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+			"please add the `--submit` flag",
+		)
+	}
 
 	return nil
 }

--- a/tools/generators/ethereum/command_template_content.go
+++ b/tools/generators/ethereum/command_template_content.go
@@ -219,8 +219,12 @@ func {{$contract.ShortVar}}{{$method.CapsName}}(c *cobra.Command, args []string)
 		{{- else -}}
 		cmd.PrintOutput("success")
 		{{- end }}
-	}
 
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+			"please add the ` + "`" + `--submit` + "`" + ` flag",
+		)
+	}
 
 	return nil
 }

--- a/tools/generators/ethereum/contract_parsing.go
+++ b/tools/generators/ethereum/contract_parsing.go
@@ -480,25 +480,25 @@ func isMethodConstant(method abi.Method) bool {
 
 // Converts solidity type to a Go type.
 func bindType(kind abi.Type, structs map[string]struct{}) string {
-	goType := bindStructTypeGo(kind, structs)
-
-	// Bindings for structs are expected to be generated into the `abi` package
-	// by the abigen command.
-	if kind.T == abi.TupleTy {
-		goType = "abi." + goType
-	}
-
-	return goType
+	return resolveGoType(kind, bindStructTypeGo(kind, structs))
 }
 
 // Converts solidity topic type to a Go type.
 func bindTopicType(kind abi.Type, structs map[string]struct{}) string {
-	goType := bindTopicTypeGo(kind, structs)
+	return resolveGoType(kind, bindTopicTypeGo(kind, structs))
+}
 
-	// Bindings for structs are expected to be generated into the `abi` package
-	// by the abigen command.
-	if kind.T == abi.TupleTy {
+func resolveGoType(kind abi.Type, goType string) string {
+	switch kind.T {
+	case abi.TupleTy:
+		// Bindings for structs are expected to be generated into the `abi` package
+		// by the abigen command.
 		goType = "abi." + goType
+	case abi.SliceTy:
+		// Look for a struct nested in a slice.
+		if kind.Elem.T == abi.TupleTy {
+			goType = strings.Replace(goType, "[]", "[]abi.", 1)
+		}
 	}
 
 	return goType


### PR DESCRIPTION
A struct can be nested inside a slice. For such types, we need to add
`abi.` prefix similar to what we do for tuples.

Another change we added in this PR is some context message for transaction simulation to be clear that
the transaction was just simulated and it has to be rerun with
`--submit` flag if the user wants it to have an effect.