### PR TITLE
Fix badges after change in shields.io syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = `keep-common`
 
-https://github.com/keep-network/keep-common/actions/workflows/client.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-common/Go/main?event=push&label=Go build[Go build status]]
+https://github.com/keep-network/keep-common/actions/workflows/client.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-common/client.yml?branch=main&event=push&label=Go build[Go build status]]
 
 Common libraries and tools used across Keep repositories.
 


### PR DESCRIPTION
The `shields.io` have changed the syntax of the endpoints generating status badges, resulting in showing false failure status when old syntax was used. Updating the READMEs to use the new syntax.
Read more: badges/shields#8671.

Refs:
https://github.com/keep-network/sortition-pools/pull/198
https://github.com/keep-network/keep-core/pull/3449
https://github.com/keep-network/tbtc-v2/pull/429
https://github.com/keep-network/coverage-pools/pull/221