### PR TITLE
Changing connectivity retry attempts from Error to Warn level

### DIFF
--- a/tools/generators/ethereum/contract_events.go.tmpl
+++ b/tools/generators/ethereum/contract_events.go.tmpl
@@ -133,7 +133,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		{{$logger}}.Errorf(
+		{{$logger}}.Warnf(
 			"subscription to event {{$event.CapsName}} had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/tools/generators/ethereum/contract_events_template_content.go
+++ b/tools/generators/ethereum/contract_events_template_content.go
@@ -136,7 +136,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) watch{{$event.CapsName}}(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		{{$logger}}.Errorf(
+		{{$logger}}.Warnf(
 			"subscription to event {{$event.CapsName}} had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",


### PR DESCRIPTION
A client might experience some connectivity issues with Alchemy / Infura and will retry to reconnect. These attempts shouldn't be logged at the Error level as they don't require any actions from the operator.