### PR TITLE
Add Sepolia to the list of supported networks

### DIFF
--- a/pkg/chain/ethereum/network.go
+++ b/pkg/chain/ethereum/network.go
@@ -8,11 +8,12 @@ const (
 	Unknown Network = iota
 	Mainnet
 	Goerli
+	Sepolia
 	Developer
 )
 
 func (n Network) String() string {
-	return []string{"unknown", "mainnet", "goerli", "developer"}[n]
+	return []string{"unknown", "mainnet", "goerli", "sepolia", "developer"}[n]
 }
 
 // ChainID returns chain id associated with the network.
@@ -22,6 +23,8 @@ func (n Network) ChainID() int64 {
 		return 1
 	case Goerli:
 		return 5
+	case Sepolia:
+		return 11155111
 	}
 	return 0
 }

--- a/pkg/chain/ethereum/network_test.go
+++ b/pkg/chain/ethereum/network_test.go
@@ -21,6 +21,10 @@ func TestNetworkString(t *testing.T) {
 			network:        Goerli,
 			expectedString: "goerli",
 		},
+		"Sepolia": {
+			network:        Sepolia,
+			expectedString: "sepolia",
+		},
 		"Developer": {
 			network:        Developer,
 			expectedString: "developer",


### PR DESCRIPTION
The Görli testnet currently used by Threshold/Keep for development purposes is planned to become deprecated with the end of year 2023. The testnet that was created to replace it is called
[Holešky](https://github.com/eth-clients/holesky), however it will take some time until it gets integrated with by some of the projects we rely on. As a solution, we decided to switch first to another testnet that is currently live - Sepolia. This testnet's EOL is planned for 2026, which gives us plenty of time to move to Holešky before Sepolia gets deprecated. Until Görli is not dead we want to support both testnets.