### PR TITLE
Remove support for Goerli testnet

### DIFF
--- a/pkg/chain/ethereum/network.go
+++ b/pkg/chain/ethereum/network.go
@@ -7,13 +7,12 @@ type Network int
 const (
 	Unknown Network = iota
 	Mainnet
-	Goerli
 	Sepolia
 	Developer
 )
 
 func (n Network) String() string {
-	return []string{"unknown", "mainnet", "goerli", "sepolia", "developer"}[n]
+	return []string{"unknown", "mainnet", "sepolia", "developer"}[n]
 }
 
 // ChainID returns chain id associated with the network.
@@ -21,8 +20,6 @@ func (n Network) ChainID() int64 {
 	switch n {
 	case Mainnet:
 		return 1
-	case Goerli:
-		return 5
 	case Sepolia:
 		return 11155111
 	}

--- a/pkg/chain/ethereum/network_test.go
+++ b/pkg/chain/ethereum/network_test.go
@@ -17,10 +17,6 @@ func TestNetworkString(t *testing.T) {
 			network:        Mainnet,
 			expectedString: "mainnet",
 		},
-		"Goerli": {
-			network:        Goerli,
-			expectedString: "goerli",
-		},
 		"Sepolia": {
 			network:        Sepolia,
 			expectedString: "sepolia",


### PR DESCRIPTION
As the Goerli testnet will become deprecated with end of year 2023 and we've already migrated to Sepolia testnet, we'll no longer need the Goerli-related code past that date.

Ref: https://github.com/threshold-network/solidity-contracts/issues/150